### PR TITLE
Add Cursor Fast Regex Search bookmark

### DIFF
--- a/app/bookmarks/bookmarks.ts
+++ b/app/bookmarks/bookmarks.ts
@@ -13,6 +13,12 @@ export type Bookmarks = Array<Bookmark>;
 
 export const BOOKMARKS: Bookmarks = [
   {
+    id: "df739c62-dacf-42b1-b175-19c29b333b58",
+    date: "2026-03-23",
+    title: "Cursor: Fast Regex Search",
+    url: "https://cursor.com/blog/fast-regex-search",
+  },
+  {
     id: "61b49b16-75af-48d1-a256-153fe7457ebe",
     date: "2026-03-21",
     title: "OpenAI: Equipping the Responses API with a computer environment",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Ticket

N/A

## Problem

The bookmarks page is missing the new Cursor blog post for fast regex search.

## Solution

Added a new item at the top of `BOOKMARKS` in `app/bookmarks/bookmarks.ts` with:
- title: `Cursor: Fast Regex Search`
- url: `https://cursor.com/blog/fast-regex-search`
- date: `2026-03-23`
- UUID generated via `make uuid`

## Testing

- `bun run lint`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9cea2cbe-24f4-4705-9e36-380b3c1af98e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9cea2cbe-24f4-4705-9e36-380b3c1af98e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

