### PR TITLE
Add Anthropic harness-design link to bookmarks

### DIFF
--- a/app/bookmarks/bookmarks.ts
+++ b/app/bookmarks/bookmarks.ts
@@ -13,6 +13,12 @@ export type Bookmarks = Array<Bookmark>;
 
 export const BOOKMARKS: Bookmarks = [
   {
+    id: "de5dbb4a-9768-4a77-966e-6f091ca4f55f",
+    date: "2026-03-28",
+    title: "Anthropic: Harness Design for Long-Running Apps",
+    url: "https://www.anthropic.com/engineering/harness-design-long-running-apps",
+  },
+  {
     id: "3345214d-d133-4fdf-89ba-1b9ab4e3fc7a",
     date: "2026-03-23",
     title: "A Peek Behind Colossus, Google's File System",

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -79,7 +79,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
       <ErrorBoundary>
         <Providers>
           <body className={`${GeistSans.variable} ${GeistMono.variable} antialiased`}>
-            <div className="flex flex-col items-center w-full min-h-svh py-10 md:py-20 lg:py-25 relative">
+            <div className="flex flex-col items-center w-full min-h-svh py-10 md:py-20 relative">
               <div className="flex justify-center w-full">
                 <Navbar />
               </div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Ticket

N/A

## Problem

Two updates were requested:
1. Add the Anthropic Engineering article bookmark:
   `https://www.anthropic.com/engineering/harness-design-long-running-apps`
2. Remove the `lg:py-25` CSS utility from the main layout wrapper.

## Solution

Implemented both changes:

- Added a new top-level bookmark entry in `app/bookmarks/bookmarks.ts`:
  - date: `2026-03-28`
  - title: `Anthropic: Harness Design for Long-Running Apps`
  - url: `https://www.anthropic.com/engineering/harness-design-long-running-apps`

- Updated `app/layout.tsx` by removing `lg:py-25` from the root wrapper class list.

## Testing

- `bun run lint` passes after each change.
- Manual UI verification performed in browser:
  - `/bookmarks` shows new bookmark at top with correct date/title.
  - Clicking it opens the correct Anthropic URL, and back navigation returns to bookmarks.
  - Home page and bookmarks page both render normally after removing `lg:py-25`.

Artifacts:
[bookmarks_anthropic_article_clean_demo.mp4](https://cursor.com/agents/bc-26dbf73c-ba55-4e58-b752-a34e33d66499/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbookmarks_anthropic_article_clean_demo.mp4)
[Bookmark visible on bookmarks page](https://cursor.com/agents/bc-26dbf73c-ba55-4e58-b752-a34e33d66499/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbookmarks_anthropic_article_verified.webp)
[layout_remove_lg_py_25_verification.mp4](https://cursor.com/agents/bc-26dbf73c-ba55-4e58-b752-a34e33d66499/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flayout_remove_lg_py_25_verification.mp4)
[Layout verification on bookmarks page](https://cursor.com/agents/bc-26dbf73c-ba55-4e58-b752-a34e33d66499/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flayout_remove_lg_py_25_verified.webp)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-26dbf73c-ba55-4e58-b752-a34e33d66499"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-26dbf73c-ba55-4e58-b752-a34e33d66499"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

