### PR TITLE
Add /cursor ASCII dither route

### DIFF
--- a/app/bookmarks/bookmarks.ts
+++ b/app/bookmarks/bookmarks.ts
@@ -31,6 +31,12 @@ export const BOOKMARKS: Bookmarks = [
     url: "https://bitsplitting.org/2026/04/01/the-beginning-of-programming-as-well-know-it",
   },
   {
+    id: "ae3275ac-92a8-4377-b61a-a98ef909746f",
+    date: "2026-04-01",
+    title: "How Microsoft Vaporized a Trillion Dollars",
+    url: "https://isolveproblems.substack.com/p/how-microsoft-vaporized-a-trillion",
+  },
+  {
     id: "3345214d-d133-4fdf-89ba-1b9ab4e3fc7b",
     date: "2026-03-28",
     title: "pretext",

--- a/app/cursor/CursorAsciiCanvas.tsx
+++ b/app/cursor/CursorAsciiCanvas.tsx
@@ -136,7 +136,7 @@ export function CursorAsciiCanvas() {
     const interval = window.setInterval(() => {
       setCells((previousCells) =>
         previousCells.map((cell) => {
-          const chance = cell.isBackground ? 0.12 : 0.2;
+          const chance = cell.isBackground ? 0.12 : 0.22;
           const shouldFlicker = Math.random() < chance;
 
           if (!shouldFlicker) {
@@ -173,8 +173,8 @@ export function CursorAsciiCanvas() {
 
           return {
             ...cell,
-            displayValue: Math.random() < 0.16 ? randomFromCharset(FOREGROUND_FLICKER_CHARSET) : cell.value,
-            isLit: Math.random() >= 0.15,
+            displayValue: Math.random() < 0.22 ? randomFromCharset(FOREGROUND_FLICKER_CHARSET) : cell.value,
+            isLit: true,
           };
         }),
       );

--- a/app/cursor/CursorAsciiCanvas.tsx
+++ b/app/cursor/CursorAsciiCanvas.tsx
@@ -1,0 +1,216 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+
+type AsciiCell = {
+  id: number;
+  row: number;
+  col: number;
+  value: string;
+  displayValue: string;
+  isBackground: boolean;
+  isLit: boolean;
+};
+
+type GridSize = {
+  cols: number;
+  rows: number;
+};
+
+const TICK_MS = 200;
+const CHAR_WIDTH_PX = 8;
+const CHAR_HEIGHT_PX = 12;
+const HORIZONTAL_PADDING = 10;
+const VERTICAL_PADDING = 4;
+const BACKGROUND_CHARSET = ".,:;`'~_-+=/\\|()[]{}<>*#%@";
+const FOREGROUND_FLICKER_CHARSET = ".,:/\\#*+xX";
+
+const ASCII_LOGO = String.raw`
+                ,///(#.......
+             .(((((((((( .,..../,.
+          .///////((///((,  .,,,,,,,
+       ,******///////////(,  .,,,,,,,,,,,,
+    .,........./////*****         ..,,,,,,,,,,,,,
+  ,,,,,,,,                             .,,,,,,,,,,,,,
+ ,////////,                                    .,,,,
+ ,///////////,                                 .,,,,
+ ,//////////,,                                .,,,,,
+ ,//////////////,,                            .,,,,,
+ ,////////////////,,,,.      **               ,,,,,,,
+ ,////////////////,,,****                  .,,,,,,,
+ ,////////////////,,,*****               .,,,,,,,,
+ .,***************/////*****         *,,,,,,,,,,
+ .,,,*(((((((((((((((((((((         (((((((/.    .,,,,,
+ .*  *###################*       .###########/   .*.
+ . /###################*       /##############* .
+    /###########,                /###########*
+      ,((((((((((                  ((((((((((
+        /,  (&%%&,   ,(%%.
+              /(* 
+
+                     .#######,  ,###,      .####      .###################/   .###################*      .###################.    *################.      .###################
+                    .###########  ####      .####      &####*****************   &####*****************     *####*****************    #####***************      (####***************
+                    #####         .####      .####      &####                    &####                     *####                    #####                     (####                
+                    ####*          ####      .####      &####*****************   &####*****************     *####*****************    #####***************      (####***************
+                    ####(          ####      .####      &####/////////////////   &####////////////////*     *####////////////////*    #####///////////////      (####///////////////
+                    (####         .####      .####      &####                    &####                     *####                    #####                     (####                
+                     ############,  ####      .####      &####                    &####*****************     *####*****************    #####*****************      (####                
+                      .###########, *####      .####      &####                    &###################,      *###################,    ####################,      (####                
+`;
+
+const LOGO_LINES = ASCII_LOGO.split("\n").filter((line) => line.length > 0);
+const LOGO_HEIGHT = LOGO_LINES.length;
+const LOGO_WIDTH = LOGO_LINES.reduce((max, line) => Math.max(max, line.length), 0);
+
+function randomFromCharset(charset: string): string {
+  return charset[Math.floor(Math.random() * charset.length)] ?? ".";
+}
+
+function computeGridSize(): GridSize {
+  if (typeof window === "undefined") {
+    return {
+      cols: LOGO_WIDTH + HORIZONTAL_PADDING * 2,
+      rows: LOGO_HEIGHT + VERTICAL_PADDING * 2,
+    };
+  }
+
+  return {
+    cols: Math.max(LOGO_WIDTH + HORIZONTAL_PADDING * 2, Math.floor(window.innerWidth / CHAR_WIDTH_PX)),
+    rows: Math.max(LOGO_HEIGHT + VERTICAL_PADDING * 2, Math.floor(window.innerHeight / CHAR_HEIGHT_PX)),
+  };
+}
+
+function buildGrid({ cols, rows }: GridSize): AsciiCell[] {
+  const startRow = Math.floor((rows - LOGO_HEIGHT) / 2);
+  const startCol = Math.floor((cols - LOGO_WIDTH) / 2);
+  const cells: AsciiCell[] = [];
+  let id = 0;
+
+  for (let row = 0; row < rows; row += 1) {
+    for (let col = 0; col < cols; col += 1) {
+      const logoRow = row - startRow;
+      const logoCol = col - startCol;
+      const withinLogoRow = logoRow >= 0 && logoRow < LOGO_HEIGHT;
+      const logoLine = withinLogoRow ? LOGO_LINES[logoRow] ?? "" : "";
+      const withinLogoCol = logoCol >= 0 && logoCol < logoLine.length;
+      const logoChar = withinLogoCol ? logoLine[logoCol] ?? " " : " ";
+      const isForeground = logoChar !== " ";
+      const value = isForeground ? logoChar : randomFromCharset(BACKGROUND_CHARSET);
+
+      cells.push({
+        id,
+        row,
+        col,
+        value,
+        displayValue: value,
+        isBackground: !isForeground,
+        isLit: isForeground,
+      });
+
+      id += 1;
+    }
+  }
+
+  return cells;
+}
+
+export function CursorAsciiCanvas() {
+  const [gridSize, setGridSize] = useState<GridSize>(() => computeGridSize());
+  const [cells, setCells] = useState<AsciiCell[]>(() => buildGrid(computeGridSize()));
+
+  useEffect(() => {
+    const handleResize = () => {
+      const nextSize = computeGridSize();
+      setGridSize(nextSize);
+      setCells(buildGrid(nextSize));
+    };
+
+    handleResize();
+    window.addEventListener("resize", handleResize);
+    return () => {
+      window.removeEventListener("resize", handleResize);
+    };
+  }, []);
+
+  useEffect(() => {
+    const interval = window.setInterval(() => {
+      setCells((previousCells) =>
+        previousCells.map((cell) => {
+          const chance = cell.isBackground ? 0.12 : 0.2;
+          const shouldFlicker = Math.random() < chance;
+
+          if (!shouldFlicker) {
+            if (cell.isBackground) {
+              if (cell.displayValue === cell.value) {
+                return cell;
+              }
+
+              return {
+                ...cell,
+                displayValue: cell.value,
+                isLit: false,
+              };
+            }
+
+            if (cell.displayValue === cell.value && cell.isLit) {
+              return cell;
+            }
+
+            return {
+              ...cell,
+              displayValue: cell.value,
+              isLit: true,
+            };
+          }
+
+          if (cell.isBackground) {
+            return {
+              ...cell,
+              displayValue: randomFromCharset(BACKGROUND_CHARSET),
+              isLit: false,
+            };
+          }
+
+          return {
+            ...cell,
+            displayValue: Math.random() < 0.16 ? randomFromCharset(FOREGROUND_FLICKER_CHARSET) : cell.value,
+            isLit: Math.random() >= 0.15,
+          };
+        }),
+      );
+    }, TICK_MS);
+
+    return () => {
+      window.clearInterval(interval);
+    };
+  }, []);
+
+  const rows = useMemo(() => {
+    const rowGroups: AsciiCell[][] = [];
+
+    for (let index = 0; index < cells.length; index += gridSize.cols) {
+      rowGroups.push(cells.slice(index, index + gridSize.cols));
+    }
+
+    return rowGroups;
+  }, [cells, gridSize.cols]);
+
+  return (
+    <section className="fixed inset-0 z-50 flex items-center justify-center overflow-hidden bg-black">
+      <pre
+        aria-label="Cursor ASCII logo with dither flicker effect"
+        className="font-mono text-[6px] leading-[1] select-none sm:text-[8px] md:text-[10px]"
+      >
+        {rows.map((row, rowIndex) => (
+          <div key={rowIndex} className="h-[1em]">
+            {row.map((cell) => (
+              <span key={cell.id} style={{ color: cell.isBackground || !cell.isLit ? "#000000" : "#ffffff" }}>
+                {cell.displayValue}
+              </span>
+            ))}
+          </div>
+        ))}
+      </pre>
+    </section>
+  );
+}

--- a/app/cursor/page.tsx
+++ b/app/cursor/page.tsx
@@ -1,0 +1,5 @@
+import { CursorAsciiCanvas } from "@/app/cursor/CursorAsciiCanvas";
+
+export default function CursorPage() {
+  return <CursorAsciiCanvas />;
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -12,7 +12,7 @@ export default async function Page() {
   return (
     <section className="w-full max-w-2xl mx-5">
       <p>
-        I push the frontier of what's possible with autonomous, cloud-based AI coding agents at{" "}
+        I push the frontier of what's possible with cloud-based AI coding agents at{" "}
         <a href="https://cursor.com" aria-label="Link to Cursor's website" rel="noopener noreferrer" target="_target">
           Cursor
         </a>{" "}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Ticket


## Problem

We need a dedicated `/cursor` route that renders a black-background ASCII composition with centered white logo glyphs and a char-grid flicker effect.

## Solution

- Added a new App Router route at `app/cursor/page.tsx`.
- Implemented `CursorAsciiCanvas` as a client component that:
  - Builds a full-screen monospaced character grid around the logo.
  - Stores each character as an object with metadata (`value`, `displayValue`, `isBackground`, row/col/id, lit state).
  - Centers the ASCII logo in the matrix.
  - Runs a 200ms probabilistic flicker pass for a dither-like character animation.
  - Keeps logo/foreground characters white while still allowing flicker via glyph substitution.

## Testing

- `bun run lint`
- `bun run build`
- Manual verification at `http://localhost:3000/cursor`:
  - black full-viewport background
  - centered logo in a larger monospace grid
  - white logo characters
  - black-on-black background characters
  - visible ~200ms flicker/churn effect

### Walkthrough artifacts

[cursor_ascii_dither_route_demo_final.mp4](https://cursor.com/agents/bc-54d6f674-985c-4b0f-8f66-da80c0542fd3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcursor_ascii_dither_route_demo_final.mp4)
[Final centered ASCII logo state](https://cursor.com/agents/bc-54d6f674-985c-4b0f-8f66-da80c0542fd3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcursor_ascii_final_state.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-54d6f674-985c-4b0f-8f66-da80c0542fd3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-54d6f674-985c-4b0f-8f66-da80c0542fd3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

