### PR TITLE
Add bikes page

### DIFF
--- a/app/bikes/page.tsx
+++ b/app/bikes/page.tsx
@@ -1,0 +1,64 @@
+import Link from "next/link";
+import { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Bikes | Nathan Thomas",
+  description: "Why I love bicycles—riding, fixing, and the freedom of two wheels.",
+  metadataBase: new URL("https://www.nathanthomas.dev"),
+  openGraph: {
+    title: "Bikes",
+    description: "Why I love bicycles—riding, fixing, and the freedom of two wheels.",
+    url: "https://www.nathanthomas.dev/bikes",
+    siteName: "Nathan Thomas",
+    locale: "en_US",
+    type: "website",
+    images: [{ url: "/opengraph-image" }],
+  },
+};
+
+export default function Page() {
+  return (
+    <section className="w-full max-w-2xl mx-5">
+      <p>
+        I really like bikes. Not in a casual “I should ride more” way—in a this-makes-me-happier, clearer-headed, and more
+        connected to the world kind of way. Two wheels, a chain, and pedals turn an ordinary day into something that
+        feels alive.
+      </p>
+      <h2 className="mt-5">What I love about them</h2>
+      <ul className="mt-4">
+        <li>
+          <strong className="font-medium">Motion without noise.</strong> You hear wind, tires on pavement, birds, and
+          your own breathing. It is the opposite of being sealed in a box.
+        </li>
+        <li>
+          <strong className="font-medium">Honest effort.</strong> Hills do not care about your resume. You earn the
+          downhill.
+        </li>
+        <li>
+          <strong className="font-medium">Simple machines, deep rabbit holes.</strong> You can ride a bike forever
+          without thinking about it—or spend a lifetime learning bearings, gearing, fit, and tires. Both are good.
+        </li>
+        <li>
+          <strong className="font-medium">Cities open up.</strong> Short trips stop feeling like chores. Coffee, a
+          friend, a sunset—you are already outside.
+        </li>
+      </ul>
+      <h2 className="mt-5">The small rituals</h2>
+      <p className="mt-4">
+        Checking tire pressure. Oiling the chain after rain. The click of a good shifter. Rolling away from the curb
+        when the light turns. These tiny habits add up to a life that feels less rushed and more intentional.
+      </p>
+      <h2 className="mt-5">If you are curious</h2>
+      <p className="mt-4">
+        You do not need the perfect bike to start—you need one that fits and a route you enjoy. I will keep writing
+        elsewhere on this site about tech and work; this page is just here to say: bikes are wonderful, and I am glad
+        they exist.
+      </p>
+      <p className="mt-5">
+        <Link aria-label="Back to Nathan's home page" href="/">
+          ← Home
+        </Link>
+      </p>
+    </section>
+  );
+}

--- a/app/components/Navbar.tsx
+++ b/app/components/Navbar.tsx
@@ -19,6 +19,7 @@ export function Navbar() {
   const pathname = usePathname();
   const isHomePage = pathname === "/";
   const isBookmarksPage = pathname === "/bookmarks";
+  const isBikesPage = pathname === "/bikes";
   const isBooksPage = pathname === "/books";
   const isWritingPage = pathname === "/writing";
   const isCursorPage = pathname === "/cursor";
@@ -43,6 +44,8 @@ export function Navbar() {
   );
   if (isBookmarksPage) {
     titleText = <h1>Bookmarks</h1>;
+  } else if (isBikesPage) {
+    titleText = <h1>Bikes</h1>;
   } else if (isBooksPage) {
     titleText = <h1>Books</h1>;
   } else if (isWritingPage) {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -114,6 +114,10 @@ export default async function Page() {
         <Link aria-label="Link to Nathan's bookmarks" href="/bookmarks">
           bookmarks
         </Link>
+        ,{" "}
+        <Link aria-label="Link to Nathan's bikes page" href="/bikes">
+          bikes
+        </Link>
         , <Link href="/books">booklist</Link>,{" "}
         <a
           href="https://nathanthomas.substack.com/"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a new static page at `/bikes` celebrating bicycles—why they matter, what makes riding rewarding, and a short invitation to try it—with metadata aligned to other site pages (bookmarks, books).

## Changes

- **`app/bikes/page.tsx`** — New page with sections on what makes bikes great, small rituals of riding, and a gentle closing note; includes a link back home.
- **`app/components/Navbar.tsx`** — Shows **Bikes** as the page title when visiting `/bikes`, consistent with Bookmarks, Books, and Writing.
- **`app/page.tsx`** — Adds a **bikes** link in the home page footer paragraph next to writing and bookmarks.

## Verification

- `bun run lint` and `bun run build` both pass.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1fb1d4bd-71ed-473f-8bb9-8dbc9411b4f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1fb1d4bd-71ed-473f-8bb9-8dbc9411b4f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

