### PR TITLE
Revert cursor page alive cell color to gray

### DIFF
--- a/app/components/CursorAsciiFill.tsx
+++ b/app/components/CursorAsciiFill.tsx
@@ -25,7 +25,7 @@ function fontSizePxForViewportWidth(w: number): number {
 }
 
 const BLACK = "#000000";
-const ALIVE_COLOR = "#341809";
+const ALIVE_COLOR = "#181818";
 const LOGO_WHITE = "#f7f7f7";
 const LOGO_EDGE_SHADOW_BLUR = 1.15;
 const LOGO_EDGE_SHADOW = "rgba(255, 255, 255, 0.42)";


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The `/cursor` Game of Life canvas used an orangish alive-cell fill (`#341809`). This restores the previous dark gray (`#181818`) from before that change.

**Change:** `ALIVE_COLOR` in `CursorAsciiFill.tsx` is set back to `#181818`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e92e94f2-e0b0-4f8d-9713-f9ea38bc7901"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e92e94f2-e0b0-4f8d-9713-f9ea38bc7901"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

