### PR TITLE
fix: zero-pad bookmark date 2026-04-07

### DIFF
--- a/app/bookmarks/bookmarks.ts
+++ b/app/bookmarks/bookmarks.ts
@@ -50,7 +50,7 @@ export const BOOKMARKS: Bookmarks = [
   },
   {
     id: "ece29db4-6791-4013-a5d1-bee5c9f83287",
-    date: "2026-04-7",
+    date: "2026-04-07",
     title: "OpenAI: Designing Delightful Frontends with GPT-5.4",
     url: "https://developers.openai.com/blog/designing-delightful-frontends-with-gpt-5-4",
   },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Corrects the bookmark `date` field in `app/bookmarks/bookmarks.ts` from `2026-04-7` to `2026-04-07` for a valid zero-padded ISO-8601 day.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-794bdb52-c21e-42ad-b495-e5ceec62fe9d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-794bdb52-c21e-42ad-b495-e5ceec62fe9d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

