### PR TITLE
feat: add SpaceX and Anthropic research bookmarks

### DIFF
--- a/app/bookmarks/bookmarks.ts
+++ b/app/bookmarks/bookmarks.ts
@@ -13,6 +13,19 @@ export type Bookmarks = Array<Bookmark>;
 
 export const BOOKMARKS: Bookmarks = [
   {
+    id: "eb1c2d25-9b34-4c8d-89e9-e9bc66d1a144",
+    date: "2026-04-24",
+    title: "Cursor: Partnering with SpaceX on model training",
+    url: "https://cursor.com/blog/spacex-model-training",
+  },
+  {
+    id: "ac0a8c89-19ec-4a21-b198-201bdae82ffb",
+    date: "2026-04-24",
+    title:
+      "Anthropic: Automated Alignment Researchers: Using large language models to scale scalable oversight",
+    url: "https://www.anthropic.com/research/automated-alignment-researchers",
+  },
+  {
     id: "e3ad1fd5-1f82-4f4f-b2f6-612ac232621a",
     date: "2026-04-21",
     title: "TypeScript 7.0 Beta",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds two bookmarks (dated 2026-04-24):

- [Cursor: Partnering with SpaceX on model training](https://cursor.com/blog/spacex-model-training)
- [Anthropic: Automated Alignment Researchers](https://www.anthropic.com/research/automated-alignment-researchers)

New entries are prepended in `app/bookmarks/bookmarks.ts` to match the existing newest-first list order.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-794bdb52-c21e-42ad-b495-e5ceec62fe9d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-794bdb52-c21e-42ad-b495-e5ceec62fe9d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

