### PR TITLE
fix(bookmarks): hyphen before Anthropic AAR bookmark subtitle

### DIFF
--- a/app/bookmarks/bookmarks.ts
+++ b/app/bookmarks/bookmarks.ts
@@ -22,7 +22,7 @@ export const BOOKMARKS: Bookmarks = [
     id: "ac0a8c89-19ec-4a21-b198-201bdae82ffb",
     date: "2026-04-24",
     title:
-      "Anthropic: Automated Alignment Researchers: Using large language models to scale scalable oversight",
+      "Anthropic: Automated Alignment Researchers - Using large language models to scale scalable oversight",
     url: "https://www.anthropic.com/research/automated-alignment-researchers",
   },
   {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The recent Anthropic bookmark used two colons in a row (`Source: Part: Subtitle`), which reads like a double separator. The second separator is now a spaced hyphen so the title reads `Anthropic: Automated Alignment Researchers - Using large language models to scale scalable oversight`, matching the intended "second hyphen" punctuation.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8c899c9c-1352-4af4-8159-98076677e844"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8c899c9c-1352-4af4-8159-98076677e844"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

