### PR TITLE
Add ET Brutus to bookmarks

### DIFF
--- a/app/bookmarks/bookmarks.ts
+++ b/app/bookmarks/bookmarks.ts
@@ -13,6 +13,12 @@ export type Bookmarks = Array<Bookmark>;
 
 export const BOOKMARKS: Bookmarks = [
   {
+    id: "ef536439-2ecd-4a7e-89e3-a81310eb43d0",
+    date: "2026-04-28",
+    title: "ET Brutus",
+    url: "https://www.etbrutus.com/",
+  },
+  {
     id: "eb1c2d25-9b34-4c8d-89e9-e9bc66d1a144",
     date: "2026-04-24",
     title: "Cursor: Partnering with SpaceX on model training",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Ticket

N/A

## Problem

The bookmarks list did not include https://www.etbrutus.com/.

## Solution

Add a new bookmark entry at the top of `BOOKMARKS` in `app/bookmarks/bookmarks.ts` with title "ET Brutus", today's date, and a stable UUID for the Atom feed entry id.

## Testing

Ran `bun run lint` successfully.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c55071d9-bacb-4bd9-8115-273660aefd5b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c55071d9-bacb-4bd9-8115-273660aefd5b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

