### PR TITLE
Update default OG image tagline to Engineering at Cursor

### DIFF
--- a/app/opengraph-image/route.tsx
+++ b/app/opengraph-image/route.tsx
@@ -27,7 +27,7 @@ export async function GET() {
             <span tw="text-gray-500 shrink-0 mt-1 mr-3 text-[28px] leading-none" style={{ fontFamily: "Geist Sans" }}>
               ‣
             </span>
-            <span style={{ fontFamily: "Geist Mono" }}>Software Engineer on Sabbatical</span>
+            <span style={{ fontFamily: "Geist Mono" }}>Engineering at Cursor</span>
           </div>
           <div tw="flex flex-row items-start gap-x-4 text-3xl my-2">
             <span tw="text-gray-500 shrink-0 mt-1 mr-3 text-[28px] leading-none" style={{ fontFamily: "Geist Sans" }}>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Ticket

N/A (site copy update).

## Problem

The default Open Graph image still showed the old line “Software Engineer on Sabbatical.”

## Solution

Update `app/opengraph-image/route.tsx` so the first bullet reads “Engineering at Cursor” instead.

## Testing

Ran `bun run lint` successfully. Post images (`app/(writing)/[slug]/opengraph-image/route.tsx`) use post titles and descriptions only; no change required there.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d2fa94ae-5e61-4ba7-8d9b-219f59469ad2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d2fa94ae-5e61-4ba7-8d9b-219f59469ad2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

