### PR TITLE
Update OG image tagline to Teacher, Writer, and Speaker

### DIFF
--- a/app/opengraph-image/route.tsx
+++ b/app/opengraph-image/route.tsx
@@ -33,7 +33,7 @@ export async function GET() {
             <span tw="text-gray-500 shrink-0 mt-1 mr-3 text-[28px] leading-none" style={{ fontFamily: "Geist Sans" }}>
               ‣
             </span>
-            <span style={{ fontFamily: "Geist Mono" }}>Teacher, Writer, and Actor</span>
+            <span style={{ fontFamily: "Geist Mono" }}>Teacher, Writer, and Speaker</span>
           </div>
           <div tw="flex flex-row items-start gap-x-4 text-3xl my-2">
             <span tw="text-gray-500 shrink-0 mt-1 mr-3 text-[28px] leading-none" style={{ fontFamily: "Geist Sans" }}>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Updates the generated default Open Graph image (`/opengraph-image`) so the third bullet reads “Teacher, Writer, and Speaker” instead of “Teacher, Writer, and Actor.”

Blog post OG images use a separate route and are unchanged.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8ae9fec3-29bb-43fc-a2ff-48d585575277"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8ae9fec3-29bb-43fc-a2ff-48d585575277"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

