### PR TITLE
Add OpenAI bookmark: Where the goblins came from

### DIFF
--- a/app/bookmarks/bookmarks.ts
+++ b/app/bookmarks/bookmarks.ts
@@ -15,7 +15,7 @@ export const BOOKMARKS: Bookmarks = [
   {
     id: "e0054849-8a86-459f-a884-650f8e550658",
     date: "2026-04-29",
-    title: "OpenAI: Where the goblins came from",
+    title: "OpenAI: Where the Goblins Came From",
     url: "https://openai.com/index/where-the-goblins-came-from/",
   },
   {

--- a/app/bookmarks/bookmarks.ts
+++ b/app/bookmarks/bookmarks.ts
@@ -13,6 +13,12 @@ export type Bookmarks = Array<Bookmark>;
 
 export const BOOKMARKS: Bookmarks = [
   {
+    id: "e0054849-8a86-459f-a884-650f8e550658",
+    date: "2026-04-29",
+    title: "OpenAI: Where the goblins came from",
+    url: "https://openai.com/index/where-the-goblins-came-from/",
+  },
+  {
     id: "ef536439-2ecd-4a7e-89e3-a81310eb43d0",
     date: "2026-04-28",
     title: "ET Brutus",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Ticket

N/A

## Problem

The OpenAI article [Where the goblins came from](https://openai.com/index/where-the-goblins-came-from/) was not listed on the bookmarks page.

## Solution

Add a new entry at the top of `BOOKMARKS` in `app/bookmarks/bookmarks.ts` with the article URL, title prefixed with `OpenAI:` to match other OpenAI bookmarks, publication date `2026-04-29` from the post, and a new UUID. The bookmark title uses essay-style capitalization: **OpenAI: Where the Goblins Came From**. The bookmarks Atom feed reads from the same array, so it picks up the new item automatically.

## Testing

Ran `bun run lint` (ESLint) successfully.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-da7ae042-84fc-4a3d-a9d5-3c8d5d0bfb6f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-da7ae042-84fc-4a3d-a9d5-3c8d5d0bfb6f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

