### PR TITLE
Normalize recent bookmark titles to title case

### DIFF
--- a/app/bookmarks/bookmarks.ts
+++ b/app/bookmarks/bookmarks.ts
@@ -34,7 +34,7 @@ export const BOOKMARKS: Bookmarks = [
     id: "ac0a8c89-19ec-4a21-b198-201bdae82ffb",
     date: "2026-04-24",
     title:
-      "Anthropic: Automated Alignment Researchers - Using large language models to scale scalable oversight",
+      "Anthropic: Automated Alignment Researchers — Using Large Language Models to Scale Scalable Oversight",
     url: "https://www.anthropic.com/research/automated-alignment-researchers",
   },
   {
@@ -118,7 +118,7 @@ export const BOOKMARKS: Bookmarks = [
   {
     id: "3345214d-d133-4fdf-89ba-1b9ab4e3fc7b",
     date: "2026-03-28",
-    title: "pretext",
+    title: "Pretext",
     url: "https://github.com/chenglou/pretext",
   },
   {
@@ -184,7 +184,7 @@ export const BOOKMARKS: Bookmarks = [
   {
     id: "974a6e55-ad8a-41f4-84f9-a6447a4f5da0",
     date: "2026-03-20",
-    title: "AirBnB: visx",
+    title: "Airbnb: visx",
     url: "https://visx.airbnb.tech",
   },
   {
@@ -214,13 +214,13 @@ export const BOOKMARKS: Bookmarks = [
   {
     id: "6163af08-6292-4141-b0f6-9ad665c60e28",
     date: "2026-03-17",
-    title: "vite+",
+    title: "Vite+",
     url: "https://viteplus.dev",
   },
   {
     id: "6163af08-6292-4141-b0f6-9ad665c60e27",
     date: "2026-03-16",
-    title: "Tanstack AI",
+    title: "TanStack AI",
     url: "https://tanstack.com/ai",
   },
   {

--- a/app/bookmarks/bookmarks.ts
+++ b/app/bookmarks/bookmarks.ts
@@ -118,7 +118,7 @@ export const BOOKMARKS: Bookmarks = [
   {
     id: "3345214d-d133-4fdf-89ba-1b9ab4e3fc7b",
     date: "2026-03-28",
-    title: "Pretext",
+    title: "pretext",
     url: "https://github.com/chenglou/pretext",
   },
   {
@@ -214,7 +214,7 @@ export const BOOKMARKS: Bookmarks = [
   {
     id: "6163af08-6292-4141-b0f6-9ad665c60e28",
     date: "2026-03-17",
-    title: "Vite+",
+    title: "vite+",
     url: "https://viteplus.dev",
   },
   {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Audited bookmark titles from March and April 2026 in `app/bookmarks/bookmarks.ts` against title-case conventions (major words capitalized; consistent product/brand spelling).

## Changes

- **Anthropic paper**: Title-cased the subtitle after the colon and used an em dash before it for clarity (`— Using Large Language Models to Scale Scalable Oversight`).
- **Product names**: `Tanstack AI` → `TanStack AI`.
- **Brand spelling**: `AirBnB` → `Airbnb` for the visx bookmark.
- **Lowercase branding** (per preference): `pretext` and `vite+` stay lowercase.

Other titles in that window were already in solid title case (including prefixed titles like `Cursor:` / `OpenAI:`).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-23bfe5ba-a595-462e-960c-21df496b308c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-23bfe5ba-a595-462e-960c-21df496b308c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

