### PR TITLE
Add Cursor Team Kit marketplace bookmark

### DIFF
--- a/app/bookmarks/bookmarks.ts
+++ b/app/bookmarks/bookmarks.ts
@@ -13,6 +13,12 @@ export type Bookmarks = Array<Bookmark>;
 
 export const BOOKMARKS: Bookmarks = [
   {
+    id: "173884c1-0309-44d3-b64f-3b553545f518",
+    date: "2026-05-04",
+    title: "Cursor: Team Kit",
+    url: "https://cursor.com/marketplace/cursor/cursor-team-kit",
+  },
+  {
     id: "e0054849-8a86-459f-a884-650f8e550658",
     date: "2026-04-29",
     title: "OpenAI: Where the Goblins Came From",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Ticket

N/A — user request to add a bookmark.

## Problem

The Cursor Team Kit marketplace page was not listed on the bookmarks page or Atom feed.

## Solution

Added a new entry to `BOOKMARKS` in `app/bookmarks/bookmarks.ts` with title "Cursor: Team Kit", URL `https://cursor.com/marketplace/cursor/cursor-team-kit`, and date 2026-05-04 (newest-first ordering).

## Testing

Ran `bun run lint` (ESLint); it completed with no errors.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a1ec5b8a-438d-432e-8c3e-132376b08ebd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a1ec5b8a-438d-432e-8c3e-132376b08ebd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

