### PR TITLE
Add bookmark: Cursor Bootstrapping Composer with autoinstall

### DIFF
--- a/app/bookmarks/bookmarks.ts
+++ b/app/bookmarks/bookmarks.ts
@@ -13,6 +13,12 @@ export type Bookmarks = Array<Bookmark>;
 
 export const BOOKMARKS: Bookmarks = [
   {
+    id: "a599d8f1-33a4-48fd-abdc-19529af77de5",
+    date: "2026-05-06",
+    title: "Cursor: Bootstrapping Composer with autoinstall",
+    url: "https://cursor.com/blog/bootstrapping-composer-with-autoinstall",
+  },
+  {
     id: "e0054849-8a86-459f-a884-650f8e550658",
     date: "2026-04-29",
     title: "OpenAI: Where the Goblins Came From",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds the Cursor blog post [Bootstrapping Composer with autoinstall](https://cursor.com/blog/bootstrapping-composer-with-autoinstall) to `app/bookmarks/bookmarks.ts` with date 2026-05-06. The bookmarks page and Atom feed pick up the entry automatically from the shared `BOOKMARKS` array.

Merged latest `main` so this branch also retains the **Cursor: Team Kit** bookmark (2026-05-04); the list is ordered newest-first.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7b4c8d53-1311-4d23-bc82-33045bab27d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7b4c8d53-1311-4d23-bc82-33045bab27d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

