### PR TITLE
Add Paul Graham earning bookmark

### DIFF
--- a/app/bookmarks/bookmarks.ts
+++ b/app/bookmarks/bookmarks.ts
@@ -13,6 +13,12 @@ export type Bookmarks = Array<Bookmark>;
 
 export const BOOKMARKS: Bookmarks = [
   {
+    id: "0eadb121-1bb5-4afd-8aae-9c06d801a0a7",
+    date: "2026-06-19",
+    title: "Paul Graham: How to Earn a Billion Dollars",
+    url: "https://paulgraham.com/earn.html",
+  },
+  {
     id: "c749e6b5-c85d-4c16-a3df-d74e55968ec2",
     date: "2026-06-18",
     title: "chezmoi",


### PR DESCRIPTION
### Motivation
- Add the requested Paul Graham link to the site's bookmarks so it appears in the bookmarks listing and feeds.

### Description
- Inserted a new `Bookmark` object at the top of `app/bookmarks/bookmarks.ts` with `id: "0eadb121-1bb5-4afd-8aae-9c06d801a0a7"`, `date: "2026-06-19"`, `title: "Paul Graham: How to Earn a Billion Dollars"`, and `url: "https://paulgraham.com/earn.html"`.

### Testing
- Ran `bun run lint`, which passed; running `bun run build` failed because `/workspace/website/fonts/GeistSans-Regular.ttf` is missing while collecting page data for `/opengraph-image`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a356eaedd5c8330b110ddf0b3742879)