### PR TITLE
Copy edit: simplify homepage intro text

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -12,8 +12,8 @@ export default async function Page() {
   return (
     <section className="w-full max-w-2xl mx-5">
       <p>
-        I'm a software engineer, writer, and teacher from San Francisco, CA. I'm currently on a sabbatical while
-        contributing to OSS and hacking on projects. Previously, I led core work at{" "}
+        I'm a software engineer, writer, and teacher from San Francisco, CA. I'm currently on a sabbatical and previously
+        led core work at{" "}
         <a href="https://tesla.com" aria-label="Link to Tesla's website" rel="noopener noreferrer" target="_target">
           Tesla
         </a>


### PR DESCRIPTION
### Motivation

- Tidy up and simplify the personal intro sentence on the homepage to remove a redundant clause and improve flow.

### Description

- Minor copy edit in `app/page.tsx` to reword the opening paragraph, removing the clause "while contributing to OSS and hacking on projects" and changing the phrasing to "I'm currently on a sabbatical and previously led core work at".

### Testing

- Ran a local build and typecheck (`next build` and `tsc --noEmit`) and lint (`npm run lint`); all checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a35879512a08330802d65f679663366)