### PR TITLE
Add Claude Tag bookmark

### DIFF
--- a/app/bookmarks/bookmarks.ts
+++ b/app/bookmarks/bookmarks.ts
@@ -13,6 +13,12 @@ export type Bookmarks = Array<Bookmark>;
 
 export const BOOKMARKS: Bookmarks = [
   {
+    id: "31db3218-9dc1-4e71-ac5c-edfd99b277d6",
+    date: "2026-06-22",
+    title: "Anthropic: Introducing Claude Tag",
+    url: "https://www.anthropic.com/news/introducing-claude-tag",
+  },
+  {
     id: "e7accc79-cc3c-4009-8898-102fc57cc0a8",
     date: "2026-06-22",
     title: "There Is Minimal Downside to Switching to Open Models",


### PR DESCRIPTION
### Motivation
- Add the Anthropic “Introducing Claude Tag” link to the bookmarks list so it appears on the bookmarks page.

### Description
- Insert a new bookmark entry in `app/bookmarks/bookmarks.ts` with id `31db3218-9dc1-4e71-ac5c-edfd99b277d6`, date `2026-06-22`, title `Anthropic: Introducing Claude Tag`, and URL `https://www.anthropic.com/news/introducing-claude-tag`.

### Testing
- Ran `bun run lint` and `bunx prettier --check app/bookmarks/bookmarks.ts`, both succeeded, and attempted `bun ./fonts/init.ts && bun run build`, which progressed but failed during page data collection because `REDIS_URL` was not set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3acf96f4408330b0065a5a31524937)