### PR TITLE
Add GLM-5.2 local run bookmark

### DIFF
--- a/app/bookmarks/bookmarks.ts
+++ b/app/bookmarks/bookmarks.ts
@@ -13,6 +13,12 @@ export type Bookmarks = Array<Bookmark>;
 
 export const BOOKMARKS: Bookmarks = [
   {
+    id: "4f7af642-8003-406c-bde6-622c9f622891",
+    date: "2026-06-23",
+    title: "How to Run GLM-5.2 Locally",
+    url: "https://unsloth.ai/docs/models/glm-5.2",
+  },
+  {
     id: "31db3218-9dc1-4e71-ac5c-edfd99b277d6",
     date: "2026-06-22",
     title: "Anthropic: Introducing Claude Tag",


### PR DESCRIPTION
### Motivation

- Add the Unsloth GLM-5.2 documentation link to the site's bookmarks so it appears on the Bookmarks page and can be referenced like other saved links.

### Description

- Inserted a new bookmark object into `app/bookmarks/bookmarks.ts` with title "How to Run GLM-5.2 Locally", URL `https://unsloth.ai/docs/models/glm-5.2`, and an ID generated by `make uuid`.

### Testing

- Automated checks run: `make uuid` (succeeded), `bunx prettier --write app/bookmarks/bookmarks.ts` (succeeded), `bun run lint` (succeeded), and `bun run build` (failed due to missing file `/workspace/website/fonts/GeistSans-Regular.ttf` in the environment).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3acfc66b488330a2c2079df703ede1)