### PR TITLE
Add Build a Cult bookmark

### DIFF
--- a/app/bookmarks/bookmarks.ts
+++ b/app/bookmarks/bookmarks.ts
@@ -13,6 +13,12 @@ export type Bookmarks = Array<Bookmark>;
 
 export const BOOKMARKS: Bookmarks = [
   {
+    id: "16b69c5a-9bb8-4bf9-acf7-996d8bf85dab",
+    date: "2026-06-24",
+    title: "Build a Cult: Dialog",
+    url: "https://build-a-cult.com/",
+  },
+  {
     id: "4f7af642-8003-406c-bde6-622c9f622891",
     date: "2026-06-23",
     title: "How to Run GLM-5.2 Locally",


### PR DESCRIPTION
### Motivation
- Add the provided URL and title to the site's bookmarks so it shows on the Bookmarks page.

### Description
- Inserted a new bookmark entry into `app/bookmarks/bookmarks.ts` with id `16b69c5a-9bb8-4bf9-acf7-996d8bf85dab`, date `2026-06-24`, title `Build a Cult: Dialog`, and URL `https://build-a-cult.com/`.

### Testing
- Ran `bun run lint`, which completed successfully.
- Attempted `bun run build`, which failed during page data collection due to a missing `REDIS_URL` environment variable in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3b3b4ddd048330b82dde25a6073f71)