### PR TITLE
Add GitHub apple/container to bookmarks

### DIFF
--- a/app/bookmarks/bookmarks.ts
+++ b/app/bookmarks/bookmarks.ts
@@ -13,6 +13,12 @@ export type Bookmarks = Array<Bookmark>;
 
 export const BOOKMARKS: Bookmarks = [
   {
+    id: "89821970-1b0b-431f-89b1-3164e5676842",
+    date: "2026-06-24",
+    title: "github.com/apple/container",
+    url: "https://github.com/apple/container",
+  },
+  {
     id: "16b69c5a-9bb8-4bf9-acf7-996d8bf85dab",
     date: "2026-06-24",
     title: "Build a Cult: Dialog",


### PR DESCRIPTION
### Motivation

- Add a new bookmark entry for the Apple container repository so it appears on the bookmarks page. 

### Description

- Added a new bookmark object to `app/bookmarks/bookmarks.ts` with id `89821970-1b0b-431f-89b1-3164e5676842`.
- The bookmark has `date: "2026-06-24"`, `title: "github.com/apple/container"`, and `url: "https://github.com/apple/container"`.
- Committed the change with message `Add Apple container bookmark`.

### Testing

- Ran `bun run lint`, which completed successfully.
- Attempted `bun run build`; initial run failed due to missing font files, then `bun ./fonts/init.ts` was executed to populate fonts.
- Final `bun run build` failed in this environment because `REDIS_URL` is not set, so a full production build could not complete here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3c10a9f05c8330b69b820925c47df8)