### PR TITLE
Add Stripe solopreneur bookmark

### DIFF
--- a/app/bookmarks/bookmarks.ts
+++ b/app/bookmarks/bookmarks.ts
@@ -13,6 +13,12 @@ export type Bookmarks = Array<Bookmark>;
 
 export const BOOKMARKS: Bookmarks = [
   {
+    id: "dc30d799-4487-4b81-ba45-4380aa75895a",
+    date: "2026-06-25",
+    title: "Stripe: The Age of the Solopreneur",
+    url: "https://www.stripeeconomics.com/p/the-age-of-the-solopreneur",
+  },
+  {
     id: "89821970-1b0b-431f-89b1-3164e5676842",
     date: "2026-06-24",
     title: "github.com/apple/container",


### PR DESCRIPTION
### Motivation
- Add the Stripe Economics article to the site's bookmarks so it appears on the Bookmarks page.

### Description
- Inserted a new `Bookmark` entry (id `dc30d799-4487-4b81-ba45-4380aa75895a`, date `2026-06-25`, title "Stripe: The Age of the Solopreneur", URL `https://www.stripeeconomics.com/p/the-age-of-the-solopreneur`) into `app/bookmarks/bookmarks.ts` and committed the change.

### Testing
- Ran `bun run lint`, which passed; ran `bun ./fonts/init.ts` then `bun run build`, which failed because the `REDIS_URL` environment variable is not set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d8657ae1c8330851f8bf36fbc7197)