### PR TITLE
Add Anthropic skills guide bookmark

### DIFF
--- a/app/bookmarks/bookmarks.ts
+++ b/app/bookmarks/bookmarks.ts
@@ -13,6 +13,12 @@ export type Bookmarks = Array<Bookmark>;
 
 export const BOOKMARKS: Bookmarks = [
   {
+    id: "4d59d5a6-50c7-4926-a5fc-3af2c5cd0008",
+    date: "2026-06-26",
+    title: "Anthropic: The Complete Guide to Building Skills for Claude",
+    url: "https://resources.anthropic.com/hubfs/The-Complete-Guide-to-Building-Skill-for-Claude.pdf?hsLang=en",
+  },
+  {
     id: "dc30d799-4487-4b81-ba45-4380aa75895a",
     date: "2026-06-25",
     title: "Stripe: The Age of the Solopreneur",


### PR DESCRIPTION
### Motivation
- Add the Anthropic skills guide PDF to the bookmarks list so the resource is available from the site's bookmarks collection.

### Description
- Inserted a new `Bookmark` entry in `app/bookmarks/bookmarks.ts` with a generated UUID, date `2026-06-26`, the title "Anthropic: The Complete Guide to Building Skills for Claude", and the provided PDF URL.

### Testing
- Ran `bun run lint` which completed successfully, and ran `bun run build` which failed during page data collection due to a missing `REDIS_URL` for `/[slug]/opengraph-image`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3ee33721e88330b938f5a2cde2d982)