### PR TITLE
Add OpenAI: Previewing GPT-5.6 Sol bookmark

### DIFF
--- a/app/bookmarks/bookmarks.ts
+++ b/app/bookmarks/bookmarks.ts
@@ -13,6 +13,12 @@ export type Bookmarks = Array<Bookmark>;
 
 export const BOOKMARKS: Bookmarks = [
   {
+    id: "9c4ca024-3a77-4af6-84b0-9c918a7ee805",
+    date: "2026-06-27",
+    title: "OpenAI: Previewing GPT-5.6 Sol",
+    url: "https://openai.com/index/previewing-gpt-5-6-sol/",
+  },
+  {
     id: "4d59d5a6-50c7-4926-a5fc-3af2c5cd0008",
     date: "2026-06-26",
     title: "Anthropic: The Complete Guide to Building Skills for Claude",


### PR DESCRIPTION
### Motivation
- Add the provided OpenAI article to the site's bookmarks so it appears on the bookmarks page.

### Description
- Inserted a new bookmark entry in `app/bookmarks/bookmarks.ts` with id `9c4ca024-3a77-4af6-84b0-9c918a7ee805`, date `2026-06-27`, title `OpenAI: Previewing GPT-5.6 Sol`, and URL `https://openai.com/index/previewing-gpt-5-6-sol/`.

### Testing
- Ran `bunx prettier --write app/bookmarks/bookmarks.ts` and `bun run lint` successfully; an initial `bun run build` failed due to missing generated fonts and missing `REDIS_URL`, then `bun ./fonts/init.ts` was run and `REDIS_URL=localhost:6379 REDIS_TOKEN=dummy bun run build` completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3f2dab841483309f538c67730b81c5)