### PR TITLE
Update home page again

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -12,8 +12,7 @@ export default async function Page() {
   return (
     <section className="w-full max-w-2xl mx-5">
       <p>
-        I'm a founder, software engineer, writer, and teacher from San Francisco, CA. I'm currently on a sabbatical and
-        previously led core work at{" "}
+        I'm a founder, software engineer, writer, and teacher from San Francisco, CA. I previously led core work at{" "}
         <a href="https://tesla.com" aria-label="Link to Tesla's website" rel="noopener noreferrer" target="_target">
           Tesla
         </a>


### PR DESCRIPTION
### Motivation
- The homepage intro included a sabbatical clause that should be removed to reflect updated bio copy.

### Description
- Update `app/page.tsx` to remove the phrase "I'm currently on a sabbatical and" from the intro sentence so it now reads that the author previously led core work at Tesla, Loom, and Twitter (X).

### Testing
- Ran `bun run lint`, `bunx tsc --noEmit`, and `REDIS_URL=localhost:6379 REDIS_TOKEN=dummy bun run build`, all of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a41ade41a848330b065dd118beec075)