### PR TITLE
Add GPT-Live bookmark

### DIFF
--- a/app/bookmarks/bookmarks.ts
+++ b/app/bookmarks/bookmarks.ts
@@ -13,6 +13,12 @@ export type Bookmarks = Array<Bookmark>;
 
 export const BOOKMARKS: Bookmarks = [
   {
+    id: "6a40ab95-a38c-4cec-872d-2f900c6194a2",
+    date: "2026-07-08",
+    title: "OpenAI: GPT-Live",
+    url: "https://openai.com/index/introducing-gpt-live",
+  },
+  {
     id: "26b1345b-6780-4e07-b431-c363418630dc",
     date: "2026-07-07",
     title: "Tim Ferriss: Fear-setting",


### PR DESCRIPTION
### Motivation
- Add the requested bookmark entry for “OpenAI: GPT-Live” to the site's bookmarks list.

### Description
- Inserted a new bookmark object (id, date `2026-07-08`, title, and URL) into `app/bookmarks/bookmarks.ts` so it appears on the bookmarks page.

### Testing
- Ran `bun run lint`, which completed successfully.
- Ran `bun run build`, which was attempted but failed during page data collection because `REDIS_URL` is not set in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4e969d61ec83308cf7eee21f1b53f6)