### PR TITLE
Add footnotes to Tim Ferriss "Fear-setting" bookmark

### DIFF
--- a/app/bookmarks/bookmarks.ts
+++ b/app/bookmarks/bookmarks.ts
@@ -29,6 +29,10 @@ export const BOOKMARKS: Bookmarks = [
     date: "2026-07-07",
     title: "Tim Ferriss: Fear-setting",
     url: "https://tim.blog/2017/05/15/fear-setting",
+    footnotes: [
+      "https://www.youtube.com/watch?v=5J6jAC6XxAI",
+      "https://tim.blog/wp-content/uploads/2017/06/ted_ferriss_fear_setting_sample_slides.pdf",
+    ],
   },
   {
     id: "c66f1cbd-ebe4-49d3-ac19-6e1f5bd01515",


### PR DESCRIPTION
### Motivation
- Surface the primary talk and sample slides for the Tim Ferriss "Fear-setting" bookmark so readers can access the video and slides directly.

### Description
- Updated `app/bookmarks/bookmarks.ts` to add a `footnotes` array to the existing Tim Ferriss bookmark containing the YouTube talk and the PDF sample slides in the requested order.

### Testing
- Ran `bun run lint` which completed without errors.
- Ran `bunx prettier --check app/bookmarks/bookmarks.ts` which passed formatting checks.
- Ran `bunx tsc --noEmit` which completed with no TypeScript errors.
- Attempted `bun run build` which failed during page data collection because `REDIS_URL` is not set in the environment (build otherwise progressed after initializing fonts).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a50670a6b508330bfac59a752b2c286)