### PR TITLE
Add bookmark: AI-pilling Our Company: Lessons Learned

### DIFF
--- a/app/bookmarks/bookmarks.ts
+++ b/app/bookmarks/bookmarks.ts
@@ -13,6 +13,12 @@ export type Bookmarks = Array<Bookmark>;
 
 export const BOOKMARKS: Bookmarks = [
   {
+    id: "8c920da4-2146-483b-b26b-1be72b93155a",
+    date: "2026-07-10",
+    title: "AI-pilling Our Company: Lessons Learned",
+    url: "https://sierra.ai/blog/ai-pilling-our-company-lessons-learned",
+  },
+  {
     id: "be62f438-3ef8-475e-b60d-df31e6a47845",
     date: "2026-07-10",
     title: "Rewriting Bun in Rust",


### PR DESCRIPTION
### Motivation
- Add the Sierra AI article "AI-pilling Our Company: Lessons Learned" to the site's bookmarks list so it appears on the Bookmarks page.

### Description
- Inserted a new bookmark entry into `app/bookmarks/bookmarks.ts` with an `id`, `date`, `title`, and `url`, and committed the change.

### Testing
- Ran `bunx prettier --write app/bookmarks/bookmarks.ts` which completed successfully, and `bun run lint` which also succeeded; `bun run build` was attempted but failed because the environment variable `REDIS_URL` is not set (build cannot collect page data for opengraph image without it).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a511a0384308330aeaee9de97a5d950)