### PR TITLE
Add AI 2040 bookmark

### DIFF
--- a/app/bookmarks/bookmarks.ts
+++ b/app/bookmarks/bookmarks.ts
@@ -13,6 +13,12 @@ export type Bookmarks = Array<Bookmark>;
 
 export const BOOKMARKS: Bookmarks = [
   {
+    id: "623e6f3b-6950-4ecf-b86c-350c97718840",
+    date: "2026-07-11",
+    title: "AI 2040",
+    url: "https://ai-2040.com",
+  },
+  {
     id: "8c920da4-2146-483b-b26b-1be72b93155a",
     date: "2026-07-10",
     title: "AI-pilling Our Company: Lessons Learned",


### PR DESCRIPTION
### Motivation
- Add a new bookmark entry for the AI 2040 site to the bookmarks list so it appears on the site's Bookmarks page.

### Description
- Inserted a new `Bookmark` object (id, date `2026-07-11`, title `AI 2040`, url `https://ai-2040.com`) into `app/bookmarks/bookmarks.ts` inside the `BOOKMARKS` array.

### Testing
- Ran `bun run lint` which completed successfully, and ran `bun run build` which failed during page data collection because `REDIS_URL` is not set for the `/[slug]/opengraph-image` page.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5274d884b4833081c1c59c4856209e)