### PR TITLE
Add ChatGPT bookmark

### DIFF
--- a/app/bookmarks/bookmarks.ts
+++ b/app/bookmarks/bookmarks.ts
@@ -15,7 +15,7 @@ export const BOOKMARKS: Bookmarks = [
   {
     id: "c2d43fae-0712-43a6-808d-b46b830613ab",
     date: "2026-07-14",
-    title: "ChatGPT",
+    title: "CheatGPT",
     url: "https://blog.humphd.org/cheatgpt",
   },
   {

--- a/app/bookmarks/bookmarks.ts
+++ b/app/bookmarks/bookmarks.ts
@@ -13,6 +13,12 @@ export type Bookmarks = Array<Bookmark>;
 
 export const BOOKMARKS: Bookmarks = [
   {
+    id: "c2d43fae-0712-43a6-808d-b46b830613ab",
+    date: "2026-07-14",
+    title: "ChatGPT",
+    url: "https://blog.humphd.org/cheatgpt",
+  },
+  {
     id: "623e6f3b-6950-4ecf-b86c-350c97718840",
     date: "2026-07-11",
     title: "AI 2040",


### PR DESCRIPTION
### Motivation
- Add a new bookmark entry so the ChatGPT link appears on the site's bookmarks page.

### Description
- Inserted a `Bookmark` object into `app/bookmarks/bookmarks.ts` with id `c2d43fae-0712-43a6-808d-b46b830613ab`, date `2026-07-14`, title `ChatGPT`, and URL `https://blog.humphd.org/cheatgpt`.

### Testing
- Ran `bun run lint` (success), `bunx tsc --noEmit` (success), and `bun run build` which failed during page-data collection because `REDIS_URL` is not set in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a56466f4dd883309401f8c196b66c8b)