### PR TITLE
Add 'Cursor 0day Exploit' to bookmarks

### DIFF
--- a/app/bookmarks/bookmarks.ts
+++ b/app/bookmarks/bookmarks.ts
@@ -13,6 +13,12 @@ export type Bookmarks = Array<Bookmark>;
 
 export const BOOKMARKS: Bookmarks = [
   {
+    id: "d72c981e-b0f7-43ff-bfba-3e042195c5bc",
+    date: "2026-07-14",
+    title: "Cursor 0day Exploit",
+    url: "https://mindgard.ai/blog/cursor-0day-when-full-disclosure-becomes-the-only-protection-left",
+  },
+  {
     id: "c2d43fae-0712-43a6-808d-b46b830613ab",
     date: "2026-07-14",
     title: "CheatGPT",


### PR DESCRIPTION
### Motivation
- Add the provided Mindgard article to the site's bookmarks so it appears on the bookmarks page and feeds.

### Description
- Inserted a new bookmark entry into `app/bookmarks/bookmarks.ts` with id `d72c981e-b0f7-43ff-bfba-3e042195c5bc`, date `2026-07-14`, title `Cursor 0day Exploit`, and the supplied URL.

### Testing
- Ran `make lint` which passed, and attempted `make build` which failed because `REDIS_URL` is not set during page data collection for opengraph images (an earlier build step also required generating fonts via `bun ./fonts/init.ts`, which was executed locally).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a568e99b72c83308cb06679ba5a347b)