### PR TITLE
Add 'Meek Models Shall Inherit the Earth' bookmark

### DIFF
--- a/app/bookmarks/bookmarks.ts
+++ b/app/bookmarks/bookmarks.ts
@@ -13,6 +13,12 @@ export type Bookmarks = Array<Bookmark>;
 
 export const BOOKMARKS: Bookmarks = [
   {
+    id: "6f697ce6-1a92-4a17-8245-369a8e07963b",
+    date: "2026-07-15",
+    title: "Meek Models Shall Inherit the Earth",
+    url: "https://arxiv.org/abs/2507.07931",
+  },
+  {
     id: "91b0f6f7-9c47-4dd4-befe-7972aaec5aa0",
     date: "2026-07-15",
     title: "Thinking Machines: Inkling - Our Open-Weights Model",


### PR DESCRIPTION
### Motivation
- Save the provided arXiv link for “Meek Models Shall Inherit the Earth” to the site's bookmarks list for later reference.

### Description
- Added a new bookmark entry to `app/bookmarks/bookmarks.ts` with a generated UUID, date `2026-07-15`, title `Meek Models Shall Inherit the Earth`, and URL `https://arxiv.org/abs/2507.07931`.

### Testing
- Ran `make lint` (succeeded), `bunx tsc --noEmit` (succeeded), and attempted `bun ./fonts/init.ts; make build` which progressed after initializing fonts but failed during page data collection due to the environment variable `REDIS_URL` not being set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a57e34fef948330886446725996abae)