### PR TITLE
Add GPT-Red bookmark

### DIFF
--- a/app/bookmarks/bookmarks.ts
+++ b/app/bookmarks/bookmarks.ts
@@ -13,6 +13,12 @@ export type Bookmarks = Array<Bookmark>;
 
 export const BOOKMARKS: Bookmarks = [
   {
+    id: "e20eee40-e168-4942-87b9-bdbb49483da3",
+    date: "2026-07-15",
+    title: "GPT-Red: Unlocking Self-Improvement for Robustness",
+    url: "https://openai.com/index/unlocking-self-improvement-gpt-red",
+  },
+  {
     id: "6f697ce6-1a92-4a17-8245-369a8e07963b",
     date: "2026-07-15",
     title: "Meek Models Shall Inherit the Earth",


### PR DESCRIPTION
### Motivation
- Add the user-provided OpenAI article to the site's bookmarks list so it appears on the bookmarks page and in feeds.

### Description
- Inserted a new bookmark entry in `app/bookmarks/bookmarks.ts` containing `id`, `date`, `title`, and `url` for the GPT-Red article.

### Testing
- Ran `make lint` which completed successfully.
- Ran `make install` which completed successfully and populated required font assets.
- Ran `make build` which progressed past TypeScript but failed during page data collection because `REDIS_URL` is not set in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a57eb8cf59083308bcafcd15820acc1)