### PR TITLE
Add "The Lost Joy of Music Piracy" to bookmarks

### DIFF
--- a/app/bookmarks/bookmarks.ts
+++ b/app/bookmarks/bookmarks.ts
@@ -13,6 +13,12 @@ export type Bookmarks = Array<Bookmark>;
 
 export const BOOKMARKS: Bookmarks = [
   {
+    id: "b2a81a69-648e-431f-9b91-25d00dd1b4b6",
+    date: "2026-07-16",
+    title: "The Lost Joy of Music Piracy",
+    url: "https://www.pigeonsandplanes.com/read/music-piracy-what-cd-oink-nine-inch-nails-streaming",
+  },
+  {
     id: "e20eee40-e168-4942-87b9-bdbb49483da3",
     date: "2026-07-15",
     title: "GPT-Red: Unlocking Self-Improvement for Robustness",


### PR DESCRIPTION
### Motivation
- Add the provided article to the bookmarks list so it appears on the site's Bookmarks page.

### Description
- Inserted a new bookmark entry in `app/bookmarks/bookmarks.ts` with id `b2a81a69-648e-431f-9b91-25d00dd1b4b6`, `date: "2026-07-16"`, `title: "The Lost Joy of Music Piracy"`, and the supplied `url`.

### Testing
- Ran `make lint` (success) and `make build` (failed during page data collection because `REDIS_URL` is not set).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a591ea72f8c8330ad86c5d78d602c87)