### PR TITLE
Add 'Bugdom' bookmark to BOOKMARKS

### DIFF
--- a/app/bookmarks/bookmarks.ts
+++ b/app/bookmarks/bookmarks.ts
@@ -13,6 +13,12 @@ export type Bookmarks = Array<Bookmark>;
 
 export const BOOKMARKS: Bookmarks = [
   {
+    id: "63c8f250-ba0e-4523-9206-0efa3896fa3a",
+    date: "2026-07-16",
+    title: "Bugdom",
+    url: "https://github.com/jorio/Bugdom",
+  },
+  {
     id: "b2a81a69-648e-431f-9b91-25d00dd1b4b6",
     date: "2026-07-16",
     title: "The Lost Joy of Music Piracy",


### PR DESCRIPTION
### Motivation
- Add a new Bookmark entry for `Bugdom` to `BOOKMARKS` so the project link is included in the bookmarks list.

### Description
- Inserted a new `Bookmark` object at the start of the `BOOKMARKS` array with `id` "63c8f250-ba0e-4523-9206-0efa3896fa3a", `date` "2026-07-16", `title` "Bugdom", and `url` "https://github.com/jorio/Bugdom".

### Testing
- Ran `tsc` type-check and the repository test suite via `npm test`, and both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5924659e04833095000a4ff8990b34)