### PR TITLE
Add Nanosaur bookmark

### DIFF
--- a/app/bookmarks/bookmarks.ts
+++ b/app/bookmarks/bookmarks.ts
@@ -13,6 +13,12 @@ export type Bookmarks = Array<Bookmark>;
 
 export const BOOKMARKS: Bookmarks = [
   {
+    id: "82d05b09-d0c4-41d2-b439-b053467278de",
+    date: "2026-07-16",
+    title: "Nanosaur",
+    url: "https://github.com/jorio/Nanosaur",
+  },
+  {
     id: "63c8f250-ba0e-4523-9206-0efa3896fa3a",
     date: "2026-07-16",
     title: "Bugdom",


### PR DESCRIPTION
### Motivation
- Add the Nanosaur GitHub repository to the site's bookmarks so it appears on the bookmarks page and in the Atom feed.

### Description
- Inserted a new bookmark entry for "Nanosaur" in `app/bookmarks/bookmarks.ts` with a generated UUID, date `2026-07-16`, title `Nanosaur`, and URL `https://github.com/jorio/Nanosaur`.

### Testing
- Ran `make lint`, which completed without errors.
- Ran `make build`; the build reached compilation and TypeScript checks but failed during page data collection first due to missing font files and then (after initializing fonts) due to an unset `REDIS_URL`, so full production build could not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5926af0df08330a64db2ac7f3f0731)