### PR TITLE
Add Paul's Online Math Notes bookmark

### DIFF
--- a/app/bookmarks/bookmarks.ts
+++ b/app/bookmarks/bookmarks.ts
@@ -13,6 +13,12 @@ export type Bookmarks = Array<Bookmark>;
 
 export const BOOKMARKS: Bookmarks = [
   {
+    id: "99acf6c2-353a-49e7-bb00-94a9d4572755",
+    date: "2026-07-21",
+    title: "Paul's Online Math Notes",
+    url: "https://tutorial.math.lamar.edu",
+  },
+  {
     id: "a250799a-3a6f-41d3-aeb6-011e7f16dd11",
     date: "2026-07-20",
     title: "Cursor: Agent Swarms and the New Model Economics",


### PR DESCRIPTION
### Motivation
- Add a user-requested bookmark entry to the site's bookmarks list so it appears on the bookmarks page and feeds.

### Description
- Inserted a new bookmark object into `app/bookmarks/bookmarks.ts` with `id`, `date: "2026-07-21"`, `title: "Paul's Online Math Notes"`, and `url: "https://tutorial.math.lamar.edu"`.

### Testing
- Ran `make lint`, which passed.
- Ran `make install` to populate generated font assets, which completed successfully.
- Ran `make build`, which failed during page data collection because the `REDIS_URL` environment variable is not set (build error).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5fbbe3b6f4833096b8cd94bdb337bc)