### PR TITLE
Add groundfloor.careers bookmark

### DIFF
--- a/app/bookmarks/bookmarks.ts
+++ b/app/bookmarks/bookmarks.ts
@@ -13,6 +13,12 @@ export type Bookmarks = Array<Bookmark>;
 
 export const BOOKMARKS: Bookmarks = [
   {
+    id: "8c690be1-11fe-49d1-8f69-dc30ab3a3110",
+    date: "2026-07-21",
+    title: "groundfloor.careers",
+    url: "https://groundfloor.careers",
+  },
+  {
     id: "99acf6c2-353a-49e7-bb00-94a9d4572755",
     date: "2026-07-21",
     title: "Paul's Online Math Notes",


### PR DESCRIPTION
### Motivation
- Add `groundfloor.careers` to the site's bookmarks so it appears on the Bookmarks page and in feeds.

### Description
- Inserted a bookmark entry into `app/bookmarks/bookmarks.ts` (id `8c690be1-11fe-49d1-8f69-dc30ab3a3110`, date `2026-07-21`, title `groundfloor.careers`, url `https://groundfloor.careers`) and committed the change.

### Testing
- Ran `make lint` (passed); attempted `make build` which required running `bun ./fonts/init.ts` to copy local fonts and ultimately failed due to a missing `REDIS_URL` during page data collection for opengraph-image (environment issue).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5fed3dc0b483309f1a1c753c30f149)