### PR TITLE
Add bookmark: Open Weights and American AI Leadership

### DIFF
--- a/app/bookmarks/bookmarks.ts
+++ b/app/bookmarks/bookmarks.ts
@@ -13,6 +13,12 @@ export type Bookmarks = Array<Bookmark>;
 
 export const BOOKMARKS: Bookmarks = [
   {
+    id: "ea847d02-da2d-4243-852b-673fb116cac2",
+    date: "2026-07-24",
+    title: "Open Weights and American AI Leadership",
+    url: "https://images.nvidia.com/pdf/Open-Weights-and-American-AI-Leadership.pdf",
+  },
+  {
     id: "7f12ad25-e7a1-49c0-89e1-6e1017d6184c",
     date: "2026-07-22",
     title: "I Have ADHD Agent Skill",


### PR DESCRIPTION
### Motivation
- Add the provided NVIDIA PDF to the site's bookmarks so it appears on the public Bookmarks page.

### Description
- Added a new bookmark object to `app/bookmarks/bookmarks.ts` containing the title `Open Weights and American AI Leadership`, the provided NVIDIA PDF URL, and a generated UUID and date.

### Testing
- Ran `make lint` (passed) and attempted `make build`, which initially failed due to missing font files (fixed by running `bun ./fonts/init.ts`) and ultimately failed during page data collection because the `REDIS_URL` environment variable is not set in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a63c86ba8308330800319fc60b6c2f3)