### PR TITLE
Add bookmark: Making Instagram Faster Part 3: Cache First

### DIFF
--- a/app/bookmarks/bookmarks.ts
+++ b/app/bookmarks/bookmarks.ts
@@ -13,6 +13,12 @@ export type Bookmarks = Array<Bookmark>;
 
 export const BOOKMARKS: Bookmarks = [
   {
+    id: "a1f5f53d-dfc4-4a9d-a0d7-8b47293f33e0",
+    date: "2026-07-25",
+    title: "Making Instagram Faster Part 3: Cache First",
+    url: "https://instagram-engineering.com/making-instagram-com-faster-part-3-cache-first-6f3f130b9669",
+  },
+  {
     id: "ea847d02-da2d-4243-852b-673fb116cac2",
     date: "2026-07-24",
     title: "Open Weights and American AI Leadership",


### PR DESCRIPTION
### Motivation
- Add the provided Instagram Engineering article to the bookmarks list so it appears on the site’s `/bookmarks` page.

### Description
- Inserted a new bookmark object at the top of `app/bookmarks/bookmarks.ts` with `date: "2026-07-25"`, the title `"Making Instagram Faster Part 3: Cache First"`, and the supplied URL.

### Testing
- Ran `bunx prettier --check app/bookmarks/bookmarks.ts` (passed), `bun run lint` (passed), and `bunx tsc --noEmit` (passed).
- Ran `bun run build` where compilation and type-checking succeeded, but page-data collection requires `REDIS_URL` in the environment to fully collect some pages.
- Rendered `/bookmarks` locally and verified the new entry appears.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a640fea97c083309689bfc02bbe3597)