### PR TITLE
Add “The 18 Mistakes that Kill Startups” bookmark

### DIFF
--- a/app/bookmarks/bookmarks.ts
+++ b/app/bookmarks/bookmarks.ts
@@ -13,6 +13,12 @@ export type Bookmarks = Array<Bookmark>;
 
 export const BOOKMARKS: Bookmarks = [
   {
+    id: "761ba430-024e-4e11-b00c-db70a0cacdb5",
+    date: "2026-07-26",
+    title: "The 18 Mistakes that Kill Startups",
+    url: "https://paulgraham.com/startupmistakes.html",
+  },
+  {
     id: "94759da2-63aa-4c75-9c03-830431d54a86",
     date: "2026-07-26",
     title: "Web Vitals",


### PR DESCRIPTION
### Motivation
- Add Paul Graham’s essay "The 18 Mistakes that Kill Startups" to the app bookmarks so it appears in the site's bookmarks list.

### Description
- Insert a new bookmark object into `app/bookmarks/bookmarks.ts` with a generated `UUID`, date `2026-07-26`, title `The 18 Mistakes that Kill Startups`, and URL `https://paulgraham.com/startupmistakes.html`.

### Testing
- Ran `make lint` which completed successfully.
- Ran `bunx tsc --noEmit` which completed successfully.
- Ran `make build` which failed during page-data collection because `REDIS_URL` is not set in the environment, blocking a full production build.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a668af40f508330ae386d32c0dca279)