### PR TITLE
Add React Select bookmark

### DIFF
--- a/app/bookmarks/bookmarks.ts
+++ b/app/bookmarks/bookmarks.ts
@@ -13,6 +13,12 @@ export type Bookmarks = Array<Bookmark>;
 
 export const BOOKMARKS: Bookmarks = [
   {
+    id: "6fcf568c-01f0-4aed-9c25-21ae04566585",
+    date: "2026-07-26",
+    title: "React Select",
+    url: "https://react-select.com",
+  },
+  {
     id: "761ba430-024e-4e11-b00c-db70a0cacdb5",
     date: "2026-07-26",
     title: "The 18 Mistakes that Kill Startups",


### PR DESCRIPTION
### Motivation
- Add a new bookmark entry for the React Select website to the app's bookmarks list.

### Description
- Inserted a `Bookmark` object for "React Select" with URL `https://react-select.com` into `app/bookmarks/bookmarks.ts`.

### Testing
- `bunx prettier --check app/bookmarks/bookmarks.ts` passed.
- `make lint` (ESLint) passed.
- `bunx tsc --noEmit` passed.
- `git diff --check` passed.
- `make build` was attempted but failed during page-data collection because `REDIS_URL` is not set in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6692ffe4e083309b54680dbb829ab1)