### PR TITLE
Add Amazon S3 consistency bookmark

### DIFF
--- a/app/bookmarks/bookmarks.ts
+++ b/app/bookmarks/bookmarks.ts
@@ -13,6 +13,12 @@ export type Bookmarks = Array<Bookmark>;
 
 export const BOOKMARKS: Bookmarks = [
   {
+    id: "e38500cf-e660-49a8-9ae8-feaa265c5b33",
+    date: "2026-07-27",
+    title: "Amazon S3 Update – Strong Read-After-Write Consistency",
+    url: "https://aws.amazon.com/blogs/aws/amazon-s3-update-strong-read-after-write-consistency",
+  },
+  {
     id: "6fcf568c-01f0-4aed-9c25-21ae04566585",
     date: "2026-07-26",
     title: "React Select",


### PR DESCRIPTION
### Motivation
- Add the AWS blog post about S3 strong read-after-write consistency to the site's bookmarks so it appears on the bookmarks page.

### Description
- Inserted a new bookmark entry in `app/bookmarks/bookmarks.ts` with a generated UUID, date `2026-07-27`, the provided title, and the target URL.

### Testing
- Ran `bunx prettier --check app/bookmarks/bookmarks.ts`, `make lint`, and `bunx tsc --noEmit`, all of which passed, and attempted `make build` which failed in this environment due to a missing environment variable (`REDIS_URL`) required at build time.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a66dc8959c0833096ca39c379f47817)