### PR TITLE
Add Kimi K3 Open Weights bookmark

### DIFF
--- a/app/bookmarks/bookmarks.ts
+++ b/app/bookmarks/bookmarks.ts
@@ -13,6 +13,12 @@ export type Bookmarks = Array<Bookmark>;
 
 export const BOOKMARKS: Bookmarks = [
   {
+    id: "bdb19cb2-7a8b-4cae-a828-dc2f5ecc871f",
+    date: "2026-07-27",
+    title: "Kimi K3 Open Weights",
+    url: "https://x.com/Kimi_Moonshot/status/2081760186235289764",
+  },
+  {
     id: "e38500cf-e660-49a8-9ae8-feaa265c5b33",
     date: "2026-07-27",
     title: "Amazon S3 Update – Strong Read-After-Write Consistency",


### PR DESCRIPTION
### Motivation
- Add a user-provided bookmark entry for the Kimi K3 Open Weights X post to the site's bookmarks data so it appears in the bookmarks page and static data.

### Description
- Inserted a new bookmark object into `app/bookmarks/bookmarks.ts` with title `Kimi K3 Open Weights`, URL `https://x.com/Kimi_Moonshot/status/2081760186235289764`, date `2026-07-27`, and UUID `bdb19cb2-7a8b-4cae-a828-dc2f5ecc871f`.
- Kept the existing bookmarks array and typing (`Bookmark`, `Bookmarks`) unchanged.

### Testing
- Ran `bunx prettier --check app/bookmarks/bookmarks.ts` which passed. 
- Ran `make lint` which completed without reported errors. 
- Ran `bunx tsc --noEmit` which completed without type errors. 
- Ran `make build` which compiled and ran TypeScript checks but failed page-data collection due to a missing font file (`fonts/GeistSans-Regular.ttf`) in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a67ace17be083309682401f69151b3d)