### PR TITLE
Add Pinterest Masonry Layout Component bookmark

### DIFF
--- a/app/bookmarks/bookmarks.ts
+++ b/app/bookmarks/bookmarks.ts
@@ -13,6 +13,12 @@ export type Bookmarks = Array<Bookmark>;
 
 export const BOOKMARKS: Bookmarks = [
   {
+    id: "96f4626a-c5cf-478c-8dbb-b5963c5472b9",
+    date: "2026-07-27",
+    title: "Pinterest Masonry Layout Component",
+    url: "https://gestalt.pinterest.systems/v1/web/masonry",
+  },
+  {
     id: "bdb19cb2-7a8b-4cae-a828-dc2f5ecc871f",
     date: "2026-07-27",
     title: "Kimi K3 Open Weights",


### PR DESCRIPTION
### Motivation
- Add the Pinterest Gestalt masonry component to the site's bookmarks so the reference is available from the bookmarks page with a stable id and date.

### Description
- Inserted a new bookmark entry into `app/bookmarks/bookmarks.ts` containing `id`, `date`, `title`, and `url` for the Pinterest Masonry Layout Component and committed the change.

### Testing
- Ran `bunx prettier --check app/bookmarks/bookmarks.ts`, `make lint`, and `bunx tsc --noEmit`, all of which passed, and verified the bookmark in-browser using Playwright; `make build` was attempted but failed during page-data collection because `REDIS_URL` is not set in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a67b8cf6e0883309659cdb1eb116bfe)