### PR TITLE
Add Anthropic: Where We Stand on Open Weights Models to bookmarks

### DIFF
--- a/app/bookmarks/bookmarks.ts
+++ b/app/bookmarks/bookmarks.ts
@@ -13,6 +13,12 @@ export type Bookmarks = Array<Bookmark>;
 
 export const BOOKMARKS: Bookmarks = [
   {
+    id: "77e1fc8c-8772-4bdb-a904-11743de2e056",
+    date: "2026-07-28",
+    title: "Anthropic: Where We Stand on Open Weights Models",
+    url: "https://www.anthropic.com/news/position-open-weights-models",
+  },
+  {
     id: "96f4626a-c5cf-478c-8dbb-b5963c5472b9",
     date: "2026-07-27",
     title: "Pinterest Masonry Layout Component",


### PR DESCRIPTION
### Motivation
- Add the requested Anthropic position article to the site's bookmarks list for easy reference.

### Description
- Inserted a new `Bookmark` entry at the top of `app/bookmarks/bookmarks.ts` with id `77e1fc8c-8772-4bdb-a904-11743de2e056`, date `2026-07-28`, the requested title, and URL `https://www.anthropic.com/news/position-open-weights-models`.

### Testing
- Ran `bunx prettier --check app/bookmarks/bookmarks.ts` which passed.
- Ran `bun run lint` which passed.
- Ran `bunx tsc --noEmit` which passed.
- Ran `bun run build` which failed during page-data collection because `REDIS_URL` is not set in the environment (the missing font error seen earlier was resolved by running `bun ./fonts/init.ts`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a690625d25c8330b0897605276f825c)