### PR TITLE
Add "Benchmarking Opus 5 on SlopCodeBench" bookmark

### DIFF
--- a/app/bookmarks/bookmarks.ts
+++ b/app/bookmarks/bookmarks.ts
@@ -13,6 +13,12 @@ export type Bookmarks = Array<Bookmark>;
 
 export const BOOKMARKS: Bookmarks = [
   {
+    id: "717d0f8b-3e83-4e69-92ee-2bb1525d8060",
+    date: "2026-07-28",
+    title: "Benchmarking Opus 5 on SlopCodeBench",
+    url: "https://github.com/humanlayer/advanced-context-engineering-for-coding-agents/blob/main/benchmarking-opus-5-on-slop-code-bench.md",
+  },
+  {
     id: "77e1fc8c-8772-4bdb-a904-11743de2e056",
     date: "2026-07-28",
     title: "Anthropic: Where We Stand on Open Weights Models",


### PR DESCRIPTION
### Motivation
- Add the requested bookmark entry to the site's central bookmarks list for easy discovery.

### Description
- Inserted a new bookmark in `app/bookmarks/bookmarks.ts` with id `717d0f8b-3e83-4e69-92ee-2bb1525d8060`, date `2026-07-28`, title `Benchmarking Opus 5 on SlopCodeBench`, and the provided URL.

### Testing
- Ran `bunx prettier --check app/bookmarks/bookmarks.ts`, `make lint`, and `bunx tsc --noEmit`, which passed; `make build` was attempted but failed during page-data collection because `REDIS_URL` is not configured in the environment, and `bunx playwright install chromium` failed to download browsers due to a CDN 403 but is not required for this bookmark change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a69247fc9c88330a55af6b589437ef8)