### PR TITLE
Add <img> vs <picture> bookmark

### DIFF
--- a/app/bookmarks/bookmarks.ts
+++ b/app/bookmarks/bookmarks.ts
@@ -13,6 +13,12 @@ export type Bookmarks = Array<Bookmark>;
 
 export const BOOKMARKS: Bookmarks = [
   {
+    id: "bbf0570e-8bb5-4f2c-8a7e-c17be854d15e",
+    date: "2026-07-29",
+    title: "<img> vs <picture>",
+    url: "https://medium.com/@truszko1/picture-tags-vs-img-tags-their-uses-and-misuses-4b4a7881a8e1",
+  },
+  {
     id: "717d0f8b-3e83-4e69-92ee-2bb1525d8060",
     date: "2026-07-28",
     title: "Benchmarking Opus 5 on SlopCodeBench",


### PR DESCRIPTION
### Motivation
- Add the requested Medium article to the site's bookmarks collection so it appears on the bookmarks page.

### Description
- Inserted a new bookmark object in `app/bookmarks/bookmarks.ts` with `id: "bbf0570e-8bb5-4f2c-8a7e-c17be854d15e"`, `date: "2026-07-29"`, `title: "<img> vs <picture>"`, and the provided Medium `url`.
- Committed the change to the repository (push was not performed because no remote is configured in this environment).

### Testing
- Ran `bunx prettier --check app/bookmarks/bookmarks.ts`, which passed. 
- Ran `make lint` (ESLint), which produced no errors. 
- Attempted `make build`; initial runs failed due to missing font files and required environment variables (`REDIS_URL` / `REDIS_TOKEN`), so a full production build could not be validated in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6a57a4f5d48330bdef8c797caacc2b)