### PR TITLE
Add contenteditable bookmark

### DIFF
--- a/app/bookmarks/bookmarks.ts
+++ b/app/bookmarks/bookmarks.ts
@@ -13,6 +13,12 @@ export type Bookmarks = Array<Bookmark>;
 
 export const BOOKMARKS: Bookmarks = [
   {
+    id: "4b10861e-8fef-4546-866b-c771541958ea",
+    date: "2026-07-30",
+    title: "contenteditable",
+    url: "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/contenteditable",
+  },
+  {
     id: "bbf0570e-8bb5-4f2c-8a7e-c17be854d15e",
     date: "2026-07-29",
     title: "<img> vs <picture>",


### PR DESCRIPTION
### Motivation
- Add the MDN `contenteditable` reference to the site's bookmarks so it appears in the bookmarks page.

### Description
- Inserted a new bookmark into `app/bookmarks/bookmarks.ts` dated `2026-07-30` with id `4b10861e-8fef-4546-866b-c771541958ea` pointing to the MDN `contenteditable` page.

### Testing
- Ran `bunx prettier --check app/bookmarks/bookmarks.ts` (passed), `make lint` (passed), and `bunx tsc --noEmit` (passed), and attempted `make build` which failed because the `REDIS_URL` and `REDIS_TOKEN` environment variables are not set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6b9469b4c48330a3f0fc20a25f8fd9)