### PR TITLE
Add Google Docs canvas rendering bookmark

### DIFF
--- a/app/bookmarks/bookmarks.ts
+++ b/app/bookmarks/bookmarks.ts
@@ -13,6 +13,12 @@ export type Bookmarks = Array<Bookmark>;
 
 export const BOOKMARKS: Bookmarks = [
   {
+    id: "e4c0b51d-65f0-42ad-86d3-c705cdeec0e1",
+    date: "2026-07-30",
+    title: "Google Docs Will Now Use Canvas Based Rendering",
+    url: "https://workspaceupdates.googleblog.com/2021/05/Google-Docs-Canvas-Based-Rendering-Update.html",
+  },
+  {
     id: "4b10861e-8fef-4546-866b-c771541958ea",
     date: "2026-07-30",
     title: "contenteditable",


### PR DESCRIPTION
### Motivation
- Add the requested Google Workspace Updates article to the site's bookmarks so it appears in the bookmarks list.

### Description
- Inserted a new bookmark entry in `app/bookmarks/bookmarks.ts` with id `e4c0b51d-65f0-42ad-86d3-c705cdeec0e1`, date `2026-07-30`, title `Google Docs Will Now Use Canvas Based Rendering`, and the provided URL.

### Testing
- Ran `bunx prettier --check app/bookmarks/bookmarks.ts`, `make lint`, and `bunx tsc --noEmit`, which passed, and attempted `make build` which failed during page-data collection because `REDIS_URL` is not configured in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6b982fd3148330914f18da32be2020)