### PR TITLE
Add Anthropic cybersecurity evaluations bookmark

### DIFF
--- a/app/bookmarks/bookmarks.ts
+++ b/app/bookmarks/bookmarks.ts
@@ -13,6 +13,12 @@ export type Bookmarks = Array<Bookmark>;
 
 export const BOOKMARKS: Bookmarks = [
   {
+    id: "a58caf0e-2490-452e-b35e-0524b2f656b6",
+    date: "2026-07-31",
+    title: "Anthropic: Investigating Three Real-World Incidents in Our Cybersecurity Evaluations",
+    url: "https://www.anthropic.com/news/investigating-incidents-cybersecurity-evals",
+  },
+  {
     id: "e4c0b51d-65f0-42ad-86d3-c705cdeec0e1",
     date: "2026-07-30",
     title: "Google Docs Will Now Use Canvas Based Rendering",


### PR DESCRIPTION
### Motivation
- Record the user-provided Anthropic article in the project's bookmarks list so it appears in the site's bookmarks UI.

### Description
- Added a new `Bookmark` entry (id, `date: "2026-07-31"`, `title`, and `url`) to `app/bookmarks/bookmarks.ts`.

### Testing
- Ran `bunx prettier --check app/bookmarks/bookmarks.ts` after formatting, which passed.
- Ran `make lint`, which passed.
- Ran `make build`, where compilation and TypeScript checks completed but page-data collection failed because `REDIS_URL` is not set in the environment, causing the build to exit with an error.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6bec6e03d88330bc44146773f64ad9)