### PR TITLE
Add The HTTP Query Method bookmark

### DIFF
--- a/app/bookmarks/bookmarks.ts
+++ b/app/bookmarks/bookmarks.ts
@@ -13,6 +13,12 @@ export type Bookmarks = Array<Bookmark>;
 
 export const BOOKMARKS: Bookmarks = [
   {
+    id: "da4703fc-435a-4515-b8a3-11c1200e1416",
+    date: "2026-08-01",
+    title: "The HTTP Query Method",
+    url: "https://www.rfc-editor.org/rfc/rfc10008.html",
+  },
+  {
     id: "a58caf0e-2490-452e-b35e-0524b2f656b6",
     date: "2026-07-31",
     title: "Anthropic: Investigating Three Real-World Incidents in Our Cybersecurity Evaluations",


### PR DESCRIPTION
### Motivation
- Add RFC 10008 (The HTTP Query Method) to the user's bookmarks so it appears in the site's bookmarks list with the current date.

### Description
- Inserted a new bookmark object in `app/bookmarks/bookmarks.ts` with a generated UUID, `date: "2026-08-01"`, `title: "The HTTP Query Method"`, and `url: "https://www.rfc-editor.org/rfc/rfc10008.html"`.

### Testing
- Ran `bunx prettier --check app/bookmarks/bookmarks.ts` which passed. 
- Ran `make lint` which passed. 
- Ran `bunx tsc --noEmit` which passed. 
- Performed a browser smoke test of `/bookmarks` via Playwright which rendered the new entry. 
- Attempted `make build` which initially failed due to missing font assets and later failed because `REDIS_URL` was not set, so full production build is blocked by environment configuration.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6e419bc6808330b84523a6c642914b)