### PR TITLE
Add Operational Transform Visualization bookmark

### DIFF
--- a/app/bookmarks/bookmarks.ts
+++ b/app/bookmarks/bookmarks.ts
@@ -13,6 +13,12 @@ export type Bookmarks = Array<Bookmark>;
 
 export const BOOKMARKS: Bookmarks = [
   {
+    id: "15be1edf-05a7-4be0-a495-e5964a2093e0",
+    date: "2026-08-02",
+    title: "Operational Transform Visualization",
+    url: "https://operational-transformation.github.io",
+  },
+  {
     id: "da4703fc-435a-4515-b8a3-11c1200e1416",
     date: "2026-08-01",
     title: "The HTTP Query Method",


### PR DESCRIPTION
### Motivation
- Keep the bookmarks index current by adding the Operational Transform Visualization site to the list.

### Description
- Inserted a new bookmark entry at the top of `app/bookmarks/bookmarks.ts` with date `2026-08-02`, title `Operational Transform Visualization`, URL `https://operational-transformation.github.io`, and a generated UUID.

### Testing
- Ran `bunx prettier --check app/bookmarks/bookmarks.ts` (passed) and `make lint` (passed), and ran `make build` which reached compilation and TypeScript checks but failed to collect page data due to `REDIS_URL` not being set in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6edd2a09048330a146d17b8777d649)