### PR TITLE
Add OpenAI mathematics advances bookmark

### DIFF
--- a/app/bookmarks/bookmarks.ts
+++ b/app/bookmarks/bookmarks.ts
@@ -13,6 +13,12 @@ export type Bookmarks = Array<Bookmark>;
 
 export const BOOKMARKS: Bookmarks = [
   {
+    id: "6cba4ed2-0826-4f0c-9406-8a52e16468a6",
+    date: "2026-08-02",
+    title: "OpenAI: Ten Advances in Mathematics and Theoretical Computer Science",
+    url: "https://openai.com/index/ten-advances-in-mathematics",
+  },
+  {
     id: "15be1edf-05a7-4be0-a495-e5964a2093e0",
     date: "2026-08-02",
     title: "Operational Transform Visualization",


### PR DESCRIPTION
### Motivation
- Add the provided OpenAI article to the site's bookmarks so it appears on the Bookmarks page.

### Description
- Inserted a new bookmark entry in `app/bookmarks/bookmarks.ts` containing a unique `id`, date `2026-08-02`, the given title, and URL, and committed the change.

### Testing
- Ran `bunx prettier --check app/bookmarks/bookmarks.ts`, `bun run lint`, and `bunx tsc --noEmit` which passed, and attempted `bun run build` which compiled but failed page-data collection because the environment `REDIS_URL` is not set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6fd6d7f674833088f8b4a707492539)