### PR TITLE
Add bookmark: "Smaller, Faster, Safer: Running Kimi and GLM at Scale"

### DIFF
--- a/app/bookmarks/bookmarks.ts
+++ b/app/bookmarks/bookmarks.ts
@@ -13,6 +13,12 @@ export type Bookmarks = Array<Bookmark>;
 
 export const BOOKMARKS: Bookmarks = [
   {
+    id: "98a6ca24-78ef-4f6c-b6ef-d784e118dcd7",
+    date: "2026-08-04",
+    title: "Smaller, Faster, Safer: Running Kimi and GLM at Scale",
+    url: "https://blog.cloudflare.com/smaller-faster-safer-models",
+  },
+  {
     id: "6cba4ed2-0826-4f0c-9406-8a52e16468a6",
     date: "2026-08-02",
     title: "OpenAI: Ten Advances in Mathematics and Theoretical Computer Science",


### PR DESCRIPTION
### Motivation
- Record a useful Cloudflare blog post on running Kimi/GLM at scale in the site bookmarks list so it appears on the `/bookmarks` page and in the RSS feed.

### Description
- Add a new bookmark entry for "Smaller, Faster, Safer: Running Kimi and GLM at Scale" linking to `https://blog.cloudflare.com/smaller-faster-safer-models` in `app/bookmarks/bookmarks.ts`.

### Testing
- ✅ `bunx prettier --check` (formatting passes).
- ✅ `make lint` and `bunx tsc --noEmit` (ESLint/type-check reported no blocking errors).
- ❌ `make build` failed during production build with a missing font error: `ENOENT: no such file or directory, open '/workspace/website/fonts/GeistSans-Regular.ttf'` which prevented complete production build.
- ✅ `make dev` started the dev server and a Playwright screenshot was taken of the `/bookmarks` page to confirm the new entry renders in development.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7186c2605c833080a989eb80c46400)