### PR TITLE
Add Express Gateway to bookmarks

### DIFF
--- a/app/bookmarks/bookmarks.ts
+++ b/app/bookmarks/bookmarks.ts
@@ -13,6 +13,12 @@ export type Bookmarks = Array<Bookmark>;
 
 export const BOOKMARKS: Bookmarks = [
   {
+    id: "60cbe1a0-0d89-4dc7-bce5-a7ac6aad4881",
+    date: "2026-08-06",
+    title: "Express Gateway",
+    url: "https://www.express-gateway.io",
+  },
+  {
     id: "248c7b9e-fed8-4f11-84e0-0dad46c88813",
     date: "2026-08-05",
     title: "Samara",


### PR DESCRIPTION
### Motivation

- Add a new bookmark entry for the requested site so it appears on the bookmarks page.

### Description

- Inserted a `Bookmark` object for "Express Gateway" into `app/bookmarks/bookmarks.ts` with an `id`, `date`, `title`, and `url`.

### Testing

- Ran `bunx prettier --check app/bookmarks/bookmarks.ts` and it passed.
- Ran `bun run lint` and ESLint completed without errors.
- Ran `bunx tsc --noEmit` and TypeScript checked successfully.
- Attempted `bun run build`; initial build failed due to missing font files, `bun fonts/init.ts` was executed and the build was retried, but the final build failed because `REDIS_URL` is not set in this environment during page-data collection for opengraph generation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a73deb590c08330ad17b60dad0b4510)