### PR TITLE
Add Apache Cassandra Architecture bookmark

### DIFF
--- a/app/bookmarks/bookmarks.ts
+++ b/app/bookmarks/bookmarks.ts
@@ -13,6 +13,12 @@ export type Bookmarks = Array<Bookmark>;
 
 export const BOOKMARKS: Bookmarks = [
   {
+    id: "9c764c05-f5e6-4ded-958f-0a195da5cdeb",
+    date: "2026-08-06",
+    title: "Apache Cassandra Architecture",
+    url: "https://cassandra.apache.org/doc/latest/cassandra/architecture/dynamo.html",
+  },
+  {
     id: "60cbe1a0-0d89-4dc7-bce5-a7ac6aad4881",
     date: "2026-08-06",
     title: "Express Gateway",


### PR DESCRIPTION
### Motivation
- Add the provided Apache Cassandra architecture documentation to the site's bookmarks so it appears in the bookmarks listing.

### Description
- Inserted a new bookmark object into `app/bookmarks/bookmarks.ts` with id `9c764c05-f5e6-4ded-958f-0a195da5cdeb`, date `2026-08-06`, title `Apache Cassandra Architecture`, and the requested URL, and committed the change.

### Testing
- Ran `bunx prettier --check app/bookmarks/bookmarks.ts` (passed), `make lint` (passed), `bunx tsc --noEmit` (passed), verified `/bookmarks` in a headless browser (new entry rendered), and attempted `make build` which could not complete page-data collection because `REDIS_URL` is not set in the environment (build blocked).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a73fa90026c8330b4d3e4882e8e467d)