### PR TITLE
Add Operation-based CRDTs: Arrays to bookmarks

### DIFF
--- a/app/bookmarks/bookmarks.ts
+++ b/app/bookmarks/bookmarks.ts
@@ -13,6 +13,12 @@ export type Bookmarks = Array<Bookmark>;
 
 export const BOOKMARKS: Bookmarks = [
   {
+    id: "c1b496f4-857c-40d9-b255-0a76d1a43e9f",
+    date: "2026-08-07",
+    title: "Operation-based CRDTs: Arrays",
+    url: "https://www.bartoszsypytkowski.com/operation-based-crdts-arrays-1",
+  },
+  {
     id: "9c764c05-f5e6-4ded-958f-0a195da5cdeb",
     date: "2026-08-06",
     title: "Apache Cassandra Architecture",


### PR DESCRIPTION
### Motivation
- Add the referenced article to the site's bookmarks so it appears on the `/bookmarks` page.

### Description
- Inserted a new bookmark entry into `app/bookmarks/bookmarks.ts` with a generated UUID, date `2026-08-07`, title `Operation-based CRDTs: Arrays`, and the provided URL.

### Testing
- Ran `make lint` (passed) and `bunx tsc --noEmit` (passed).
- Performed a Playwright render check for `/bookmarks` which verified the new link was rendered and produced a screenshot (passed).
- Attempted `make build`, which failed / was blocked due to missing environment configuration (`REDIS_URL`) in this environment (build not completed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a751eaa9cf88330af18c154818ceb8b)