### PR TITLE
Add bookmark: Video Startup Time Metric Explained

### DIFF
--- a/app/bookmarks/bookmarks.ts
+++ b/app/bookmarks/bookmarks.ts
@@ -13,6 +13,12 @@ export type Bookmarks = Array<Bookmark>;
 
 export const BOOKMARKS: Bookmarks = [
   {
+    id: "b52cf286-ef51-4608-9c22-f766d9efda32",
+    date: "2026-08-08",
+    title: "Video Startup Time Metric Explained",
+    url: "https://www.mux.com/blog/the-video-startup-time-metric-explained",
+  },
+  {
     id: "c1b496f4-857c-40d9-b255-0a76d1a43e9f",
     date: "2026-08-07",
     title: "Operation-based CRDTs: Arrays",


### PR DESCRIPTION
### Motivation
- Add the provided Mux article to the user's saved bookmarks so it appears in the site bookmarks list.

### Description
- Inserted a new bookmark entry in `app/bookmarks/bookmarks.ts` with title "Video Startup Time Metric Explained", the Mux URL, date `2026-08-08`, and a generated UUID, and committed the change.

### Testing
- Ran `make lint` which passed.
- Ran `bunx prettier --check app/bookmarks/bookmarks.ts` which passed.
- Ran `git diff --check` which reported no issues.
- Ran `make build` which failed during page-data collection due to a missing `REDIS_URL` environment variable (compilation and TypeScript checks completed before the failure).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a76931893348330bc6a28739e3959e1)