### PR TITLE
Add "Debezium" to bookmarks

### DIFF
--- a/app/bookmarks/bookmarks.ts
+++ b/app/bookmarks/bookmarks.ts
@@ -13,6 +13,12 @@ export type Bookmarks = Array<Bookmark>;
 
 export const BOOKMARKS: Bookmarks = [
   {
+    id: "1f73bccc-5b98-4336-9f90-ce42f62bce6c",
+    date: "2026-08-09",
+    title: "Debezium",
+    url: "https://debezium.io",
+  },
+  {
     id: "3862fbfb-6be7-44aa-9de2-fe1357a548f8",
     date: "2026-08-09",
     title: "If Experience Is the Goal, Then You Always Win",


### PR DESCRIPTION
### Motivation

- Add a new bookmark entry for the Debezium site to the bookmarks collection so it appears on the site.

### Description

- Inserted a new `Bookmark` object into `app/bookmarks/bookmarks.ts` with `id` "1f73bccc-5b98-4336-9f90-ce42f62bce6c", `date` "2026-08-09", `title` "Debezium", and `url` `"https://debezium.io"`.
- Placed the new entry at the top of the `BOOKMARKS` array so it shows as the latest bookmark in the UI.

### Testing

- Ran `make lint` and it succeeded (ESLint passed).
- Ran `bunx tsc --noEmit` and it succeeded (TypeScript checks passed).
- Ran `bunx prettier --check app/bookmarks/bookmarks.ts` and it succeeded (Prettier check passed).
- Attempted `make build` during verification: initial build failed due to missing font files and subsequent builds hit an environment-related error (`REDIS_URL` not set), so a full production build did not complete; this did not affect the bookmark change itself.
- Started the dev server (`make dev`) and used a headless browser to capture the `/bookmarks` page, confirming the new "Debezium" entry is rendered in the UI.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a78eb5a2ba88330a0044a164d15c550)