### PR TITLE
Add web.dev: Rendering on the Web to bookmarks

### DIFF
--- a/app/bookmarks/bookmarks.ts
+++ b/app/bookmarks/bookmarks.ts
@@ -13,6 +13,12 @@ export type Bookmarks = Array<Bookmark>;
 
 export const BOOKMARKS: Bookmarks = [
   {
+    id: "973390d3-6f71-49b3-9bdf-bdb2ce56554f",
+    date: "2026-08-09",
+    title: "web.dev: Rendering on the Web",
+    url: "https://web.dev/rendering-on-the-web/#a-rehydration-problem-one-app-for-the-price-of-two",
+  },
+  {
     id: "1f73bccc-5b98-4336-9f90-ce42f62bce6c",
     date: "2026-08-09",
     title: "Debezium",


### PR DESCRIPTION
### Motivation
- Add the provided link to the site's bookmarks so it appears on the Bookmarks page.

### Description
- Inserted a new bookmark entry in `app/bookmarks/bookmarks.ts` with title "web.dev: Rendering on the Web", the provided URL, date `2026-08-09`, and a generated UUID, and formatted the file with Prettier.

### Testing
- Ran `bunx prettier --check app/bookmarks/bookmarks.ts`, `make lint`, and `bunx tsc --noEmit` which all succeeded, and attempted `make build` which otherwise compiled but failed page-data collection due to an unset `REDIS_URL` environment variable (builds succeeded after fonts were copied during testing).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a78fd235a708330ae9227bf63c4f8e3)