### PR TITLE
Fix mobile home footer spacing

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -84,7 +84,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
                 <Navbar />
               </div>
               <main className="flex justify-center w-full pt-10">{children}</main>
-              <div className="flex justify-center w-full pt-10 px-5">
+              <div className="flex justify-center w-full mt-auto pt-10 px-5">
                 <Footer />
               </div>
             </div>


### PR DESCRIPTION
### Motivation

- The home page showed a large blank area under the content on small viewports because the footer container did not use the flex column’s remaining space to push the footer to the bottom.

### Description

- Add `mt-auto` to the footer wrapper so the layout's column uses available space before rendering the footer, keeping the footer at the bottom on mobile screens (change in `app/layout.tsx`: the div wrapping `<Footer />` now has `mt-auto`).

### Testing

- Ran `bun run lint` and it succeeded.
- Ran `bunx tsc --noEmit` and type-checking passed.
- Ran `bunx prettier --check app/layout.tsx` and formatting passed.
- Verified layout in a mobile viewport (430×932) with a Playwright screenshot showing the footer positioned correctly; document scrollHeight matched viewport height after the change.
- Attempted production build; compilation completed but page-data collection failed because required runtime resources are missing in CI (notably `REDIS_URL`), so full `next build` page-data steps could not finish in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a79414c590c8330865da710c049be08)