### PR TITLE
bookmarks: add “WeatherNext from Google”

### DIFF
--- a/app/bookmarks/bookmarks.ts
+++ b/app/bookmarks/bookmarks.ts
@@ -13,6 +13,12 @@ export type Bookmarks = Array<Bookmark>;
 
 export const BOOKMARKS: Bookmarks = [
   {
+    id: "8fd2abad-330c-4ef8-acbe-6e3ed3ac68fb",
+    date: "2026-08-10",
+    title: "WeatherNext from Google",
+    url: "https://deepmind.google/blog/weathernext-ai-model-achieves-breakthrough-in-forecasting-cyclones",
+  },
+  {
     id: "973390d3-6f71-49b3-9bdf-bdb2ce56554f",
     date: "2026-08-09",
     title: "web.dev: Rendering on the Web",


### PR DESCRIPTION
### Motivation
- Add the user-provided bookmark for WeatherNext so it appears in the site's bookmarks list and UI.

### Description
- Inserted a new bookmark object into `app/bookmarks/bookmarks.ts` (id, date `2026-08-10`, title "WeatherNext from Google", and the provided URL).

### Testing
- Ran formatting and checks: `bunx prettier --check app/bookmarks/bookmarks.ts` (passed), `make lint` (ran), `bunx tsc --noEmit` (passed), and `make build` (failed during Next.js build due to a missing font: ENOENT '/workspace/website/fonts/GeistSans-Regular.ttf'); started the dev server and verified the new bookmark appears in the bookmarks page via a headless browser screenshot (Playwright/@sparticuz/chromium) which confirmed a bookmark count of 1.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a79531dba9c83308f0781a41a283285)