### PR TITLE
Add bookmark: Learning More about Claude's Mathematical Capabilities

### DIFF
--- a/app/bookmarks/bookmarks.ts
+++ b/app/bookmarks/bookmarks.ts
@@ -13,6 +13,12 @@ export type Bookmarks = Array<Bookmark>;
 
 export const BOOKMARKS: Bookmarks = [
   {
+    id: "eef9122d-2706-47e3-8203-54ff57c5862a",
+    date: "2026-08-10",
+    title: "Learning More about Claude's Mathematical Capabilities",
+    url: "https://www.anthropic.com/research/riemann-zeta",
+  },
+  {
     id: "9f8b0365-6fcb-4de4-9248-58aa223dbe65",
     date: "2026-08-10",
     title: "Progressive Hydration",


### PR DESCRIPTION
### Motivation
- Add the provided Anthropic research link to the site's bookmarks so it appears on the `/bookmarks` page.

### Description
- Insert a new `Bookmark` entry in `app/bookmarks/bookmarks.ts` with id `eef9122d-2706-47e3-8203-54ff57c5862a`, date `2026-08-10`, the supplied title, and URL.

### Testing
- Ran formatting check with `bunx prettier --check app/bookmarks/bookmarks.ts` which passed and formatted the file where needed. 
- Ran lint via `make lint` and a local dev page check by opening `/bookmarks` with Playwright, which showed the new item on the page. 
- Attempted production `make build` which ultimately failed during page-data collection for opengraph image generation because `REDIS_URL` is not set, so a full production build could not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7a3298fd7083308a08962b8fb11713)