### PR TITLE
Add "A11y Tutorials" bookmark

### DIFF
--- a/app/bookmarks/bookmarks.ts
+++ b/app/bookmarks/bookmarks.ts
@@ -13,6 +13,12 @@ export type Bookmarks = Array<Bookmark>;
 
 export const BOOKMARKS: Bookmarks = [
   {
+    id: "9668a976-861a-4457-ad65-eb595df6634c",
+    date: "2026-08-11",
+    title: "A11y Tutorials",
+    url: "https://www.w3.org/WAI/tutorials",
+  },
+  {
     id: "56627f35-7539-47cd-b22e-a8f141755baa",
     date: "2026-08-11",
     title: "Progressive Web Apps with Service Workers",


### PR DESCRIPTION
### Motivation
- Add a new bookmark entry for the W3C Accessibility Tutorials to the project's bookmark list.

### Description
- Inserted a new bookmark object into `app/bookmarks/bookmarks.ts` with id `9668a976-861a-4457-ad65-eb595df6634c`, date `2026-08-11`, title `A11y Tutorials`, and url `https://www.w3.org/WAI/tutorials`.

### Testing
- Ran `prettier --check` on the modified file and it passed. 
- Ran linter (`bun run lint`) and TypeScript check (`bunx tsc --noEmit`); linters/TS checks were executed with no blocking errors reported. 
- Attempted `next build` (production) which initially failed due to a missing font and later failed in the CI environment because `REDIS_URL` was not set; these are environment issues not caused by this bookmark change. 
- Ran `bun ./fonts/init.ts` and started the dev server with `REDIS_URL=redis://localhost:6379 bun run dev`, then verified the new bookmark appears on `/bookmarks` (Playwright screenshot taken).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7a6de97700833095737b919d0779a8)