### PR TITLE
Add bookmark: "Measuring Web Performance at AirBnB"

### DIFF
--- a/app/bookmarks/bookmarks.ts
+++ b/app/bookmarks/bookmarks.ts
@@ -13,6 +13,12 @@ export type Bookmarks = Array<Bookmark>;
 
 export const BOOKMARKS: Bookmarks = [
   {
+    id: "ae9fcdcd-b3be-496d-ae02-d5a95f581b62",
+    date: "2026-08-11",
+    title: "Measuring Web Performance at AirBnB",
+    url: "https://medium.com/airbnb-engineering/measuring-web-performance-at-airbnb-122da8d3ea3f",
+  },
+  {
     id: "9668a976-861a-4457-ad65-eb595df6634c",
     date: "2026-08-11",
     title: "A11y Tutorials",


### PR DESCRIPTION
### Motivation
- Add the user-provided AirBnB Medium article to the site bookmarks so it appears on the Bookmarks page and in the Atom feed.

### Description
- Inserted a new bookmark object into `app/bookmarks/bookmarks.ts` with id `ae9fcdcd-b3be-496d-ae02-d5a95f581b62`, date `2026-08-11`, title `Measuring Web Performance at AirBnB`, and the provided Medium URL.

### Testing
- Ran Prettier formatting check with `bunx prettier --check` which passed for the modified file.
- Started the dev server (`bun run dev`) and exercised the Bookmarks page; a headless browser screenshot was captured to confirm the new entry rendered.
- Invoked the TypeScript compiler (`bunx tsc --noEmit`) as part of CI checks which completed successfully in the build logs.
- Attempted a full production build (`make build`); the build failed due to a missing font asset (`fonts/GeistSans-Regular.ttf`) unrelated to the bookmark change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7a6f5b1aac83308cddee667a113c3f)