### PR TITLE
Add Shieldfont bookmark

### DIFF
--- a/app/bookmarks/bookmarks.ts
+++ b/app/bookmarks/bookmarks.ts
@@ -13,6 +13,12 @@ export type Bookmarks = Array<Bookmark>;
 
 export const BOOKMARKS: Bookmarks = [
   {
+    id: "7db5747b-1d13-4304-93bb-8a3974f6b549",
+    date: "2026-08-11",
+    title: "Shieldfont",
+    url: "https://shieldfont.org",
+  },
+  {
     id: "0005ea4d-349d-46a9-9168-2de7c2fa1544",
     date: "2026-08-11",
     title: "Building Airbnb’s Internationalization Platform",


### PR DESCRIPTION
### Motivation
- Add Shieldfont to the site bookmarks so it appears in the bookmarks list and RSS output.

### Description
- Add a new bookmark object to `app/bookmarks/bookmarks.ts` with id `7db5747b-1d13-4304-93bb-8a3974f6b549`, `date: "2026-08-11"`, `title: "Shieldfont"`, and `url: "https://shieldfont.org"`.

### Testing
- Ran formatting and checks: `bunx prettier --check` (passed), `make lint` (ran), `bunx tsc --noEmit` (ran); attempted `make build` and addressed transient build issues (missing fonts / env) by running `bun ./fonts/init.ts` and validated the app locally with `make dev` (dev server started and the bookmarks page was exercised).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7a758311688330a92fe0ff3096205a)