### PR TITLE
Add bookmark "The Dangers of Postgres Subtransactions"

### DIFF
--- a/app/bookmarks/bookmarks.ts
+++ b/app/bookmarks/bookmarks.ts
@@ -13,6 +13,12 @@ export type Bookmarks = Array<Bookmark>;
 
 export const BOOKMARKS: Bookmarks = [
   {
+    id: "5beddab2-ce8a-43b1-b2d7-99f5bb003a9d",
+    date: "2026-08-11",
+    title: "The Dangers of Postgres Subtransactions",
+    url: "https://planetscale.com/blog/the-dangers-of-postgres-subtransactions",
+  },
+  {
     id: "7db5747b-1d13-4304-93bb-8a3974f6b549",
     date: "2026-08-11",
     title: "Shieldfont",


### PR DESCRIPTION
### Motivation
- Add a new saved bookmark entry for the PlanetScale post "The Dangers of Postgres Subtransactions" to the site's bookmarks list.

### Description
- Inserted a new bookmark object into `app/bookmarks/bookmarks.ts` with id `5beddab2-ce8a-43b1-b2d7-99f5bb003a9d`, date `2026-08-11`, title `The Dangers of Postgres Subtransactions`, and URL `https://planetscale.com/blog/the-dangers-of-postgres-subtransactions`.

### Testing
- Ran `bunx prettier --check app/bookmarks/bookmarks.ts`, `make lint`, and `bunx tsc --noEmit`, which all succeeded; an attempted `make build` failed with exit code 1 because page-data collection requires the `REDIS_URL` environment variable which was not set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7b55442570833087e34ebbd29143c2)